### PR TITLE
fix(prism-agent): define db app user privileges before app starts

### DIFF
--- a/connect/lib/sql-doobie/src/main/scala/io/iohk/atala/connect/sql/repository/Migrations.scala
+++ b/connect/lib/sql-doobie/src/main/scala/io/iohk/atala/connect/sql/repository/Migrations.scala
@@ -36,7 +36,7 @@ object Migrations {
     ZLayer.fromFunction(Migrations.apply _)
 
   def initDbPrivileges(appUser: String): RIO[Transactor[Task], Unit] = {
-    val cxnIO =for {
+    val cxnIO = for {
       _ <- doobie.free.connection.createStatement.map { stm =>
         stm.execute(s"""
           | ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "$appUser"

--- a/connect/lib/sql-doobie/src/main/scala/io/iohk/atala/connect/sql/repository/Migrations.scala
+++ b/connect/lib/sql-doobie/src/main/scala/io/iohk/atala/connect/sql/repository/Migrations.scala
@@ -1,8 +1,12 @@
 package io.iohk.atala.connect.sql.repository
 
+import doobie.*
+import doobie.implicits.*
+import doobie.util.transactor.Transactor
 import io.iohk.atala.shared.db.DbConfig
 import org.flywaydb.core.Flyway
 import zio.*
+import zio.interop.catz.*
 
 final case class Migrations(config: DbConfig) {
 
@@ -30,4 +34,19 @@ final case class Migrations(config: DbConfig) {
 object Migrations {
   val layer: URLayer[DbConfig, Migrations] =
     ZLayer.fromFunction(Migrations.apply _)
+
+  def initDbPrivileges(appUser: String): RIO[Transactor[Task], Unit] = {
+    val cxnIO =for {
+      _ <- doobie.free.connection.createStatement.map { stm =>
+        stm.execute(s"""
+          | ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "$appUser"
+          """.stripMargin)
+      }
+    } yield ()
+
+    for {
+      xa <- ZIO.service[Transactor[Task]]
+      _ <- cxnIO.transact(xa)
+    } yield ()
+  }
 }

--- a/pollux/lib/sql-doobie/src/main/scala/io/iohk/atala/pollux/sql/repository/Migrations.scala
+++ b/pollux/lib/sql-doobie/src/main/scala/io/iohk/atala/pollux/sql/repository/Migrations.scala
@@ -1,8 +1,12 @@
 package io.iohk.atala.pollux.sql.repository
 
+import doobie.*
+import doobie.implicits.*
+import doobie.util.transactor.Transactor
 import io.iohk.atala.shared.db.DbConfig
 import org.flywaydb.core.Flyway
 import zio.*
+import zio.interop.catz.*
 
 final case class Migrations(config: DbConfig) {
 
@@ -31,4 +35,19 @@ final case class Migrations(config: DbConfig) {
 object Migrations {
   val layer: URLayer[DbConfig, Migrations] =
     ZLayer.fromFunction(Migrations.apply _)
+
+  def initDbPrivileges(appUser: String): RIO[Transactor[Task], Unit] = {
+    val cxnIO =for {
+      _ <- doobie.free.connection.createStatement.map { stm =>
+        stm.execute(s"""
+          | ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "$appUser"
+          """.stripMargin)
+      }
+    } yield ()
+
+    for {
+      xa <- ZIO.service[Transactor[Task]]
+      _ <- cxnIO.transact(xa)
+    } yield ()
+  }
 }

--- a/pollux/lib/sql-doobie/src/main/scala/io/iohk/atala/pollux/sql/repository/Migrations.scala
+++ b/pollux/lib/sql-doobie/src/main/scala/io/iohk/atala/pollux/sql/repository/Migrations.scala
@@ -37,7 +37,7 @@ object Migrations {
     ZLayer.fromFunction(Migrations.apply _)
 
   def initDbPrivileges(appUser: String): RIO[Transactor[Task], Unit] = {
-    val cxnIO =for {
+    val cxnIO = for {
       _ <- doobie.free.connection.createStatement.map { stm =>
         stm.execute(s"""
           | ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "$appUser"

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Main.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Main.scala
@@ -59,7 +59,7 @@ object MainApp extends ZIOAppDefault {
 
   Security.insertProviderAt(BouncyCastleProviderSingleton.getInstance(), 2)
 
-  // FIXME: remove this when db app user is provisioned from output application.
+  // FIXME: remove this when db app user have correct privileges provisioned by k8s operator.
   // This should be executed before migration to have correct privilege for new objects.
   val preMigrations = for {
     _ <- ZIO.logInfo("running pre-migration steps.")

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Main.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Main.scala
@@ -1,6 +1,7 @@
 package io.iohk.atala.agent.server
 
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton
+import io.iohk.atala.agent.server.config.AppConfig
 import io.iohk.atala.agent.server.http.ZioHttpClient
 import io.iohk.atala.agent.server.sql.Migrations as AgentMigrations
 import io.iohk.atala.agent.walletapi.service.{
@@ -58,6 +59,22 @@ object MainApp extends ZIOAppDefault {
 
   Security.insertProviderAt(BouncyCastleProviderSingleton.getInstance(), 2)
 
+  // FIXME: remove this when db app user is provisioned from output application.
+  // This should be executed before migration to have correct privilege for new objects.
+  val preMigrations = for {
+    _ <- ZIO.logInfo("running pre-migration steps.")
+    appConfig <- ZIO.service[AppConfig].provide(SystemModule.configLayer)
+    _ <- PolluxMigrations
+      .initDbPrivileges(appConfig.pollux.database.appUsername)
+      .provide(RepoModule.polluxTransactorLayer)
+    _ <- ConnectMigrations
+      .initDbPrivileges(appConfig.connect.database.appUsername)
+      .provide(RepoModule.connectTransactorLayer)
+    _ <- AgentMigrations
+      .initDbPrivileges(appConfig.agent.database.appUsername)
+      .provide(RepoModule.agentTransactorLayer)
+  } yield ()
+
   val migrations = for {
     _ <- ZIO.serviceWithZIO[PolluxMigrations](_.migrate)
     _ <- ZIO.serviceWithZIO[ConnectMigrations](_.migrate)
@@ -100,6 +117,7 @@ object MainApp extends ZIOAppDefault {
       }
       _ <- ZIO.logInfo(s"DIDComm Service port => $didCommServicePort")
 
+      _ <- preMigrations
       _ <- migrations
 
       app <- PrismAgentApp

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/sql/Migrations.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/sql/Migrations.scala
@@ -1,8 +1,12 @@
 package io.iohk.atala.agent.server.sql
 
+import doobie.*
+import doobie.implicits.*
+import doobie.util.transactor.Transactor
 import io.iohk.atala.shared.db.DbConfig
 import org.flywaydb.core.Flyway
 import zio.*
+import zio.interop.catz.*
 
 final case class Migrations(config: DbConfig) {
 
@@ -30,4 +34,19 @@ final case class Migrations(config: DbConfig) {
 object Migrations {
   val layer: URLayer[DbConfig, Migrations] =
     ZLayer.fromFunction(Migrations.apply _)
+
+  def initDbPrivileges(appUser: String): RIO[Transactor[Task], Unit] = {
+    val cxnIO =for {
+      _ <- doobie.free.connection.createStatement.map { stm =>
+        stm.execute(s"""
+          | ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "$appUser"
+          """.stripMargin)
+      }
+    } yield ()
+
+    for {
+      xa <- ZIO.service[Transactor[Task]]
+      _ <- cxnIO.transact(xa)
+    } yield ()
+  }
 }

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/sql/Migrations.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/sql/Migrations.scala
@@ -36,7 +36,7 @@ object Migrations {
     ZLayer.fromFunction(Migrations.apply _)
 
   def initDbPrivileges(appUser: String): RIO[Transactor[Task], Unit] = {
-    val cxnIO =for {
+    val cxnIO = for {
       _ <- doobie.free.connection.createStatement.map { stm =>
         stm.execute(s"""
           | ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "$appUser"


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Add a step to execute some SQL statement to refine privileges for db app user. 
DB application user provisioned by k8s operator doesn't have the right permission for RLS feature.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [x] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
