### PR TITLE
fix: prohibit tenants to use equal api keys

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyAuthenticatorImpl.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyAuthenticatorImpl.scala
@@ -42,6 +42,8 @@ case class ApiKeyAuthenticatorImpl(
               UnexpectedError("Internal error")
             case AuthenticationRepositoryError.ServiceError(message) =>
               UnexpectedError("Internal error")
+            case AuthenticationRepositoryError.AuthenticationCompromised(entityId, amt, secret) =>
+              InvalidCredentials("API key is compromised")
           }
       }
     } else {
@@ -89,11 +91,12 @@ case class ApiKeyAuthenticatorImpl(
         .mapError(cause => AuthenticationError.UnexpectedError(cause.getMessage))
       _ <- repository
         .insert(entityId, AuthenticationMethodType.ApiKey, secret)
+        .logError(s"Insert operation failed for entityId: $entityId")
         .mapError(are => AuthenticationError.UnexpectedError(are.message))
     } yield ()
   }
 
-  override def delete(entityId: _root_.java.util.UUID, apiKey: String): IO[AuthenticationError, Unit] = {
+  override def delete(entityId: UUID, apiKey: String): IO[AuthenticationError, Unit] = {
     for {
       saltAndApiKey <- ZIO.succeed(apiKeyConfig.salt + apiKey)
       secret <- ZIO
@@ -101,7 +104,7 @@ case class ApiKeyAuthenticatorImpl(
         .logError("Failed to compute SHA256 hash")
         .mapError(cause => AuthenticationError.UnexpectedError(cause.getMessage))
       _ <- repository
-        .deleteByEntityIdAndSecret(entityId, secret)
+        .deleteByEntityIdAndTypeAndSecret(entityId, AuthenticationMethodType.ApiKey, secret)
         .mapError(are => AuthenticationError.UnexpectedError(are.message))
     } yield ()
   }

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyAuthenticatorImpl.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyAuthenticatorImpl.scala
@@ -104,7 +104,7 @@ case class ApiKeyAuthenticatorImpl(
         .logError("Failed to compute SHA256 hash")
         .mapError(cause => AuthenticationError.UnexpectedError(cause.getMessage))
       _ <- repository
-        .deleteByEntityIdAndTypeAndSecret(entityId, AuthenticationMethodType.ApiKey, secret)
+        .delete(entityId, AuthenticationMethodType.ApiKey, secret)
         .mapError(are => AuthenticationError.UnexpectedError(are.message))
     } yield ()
   }

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/AuthenticationRepository.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/AuthenticationRepository.scala
@@ -52,7 +52,7 @@ trait AuthenticationRepository {
       amt: AuthenticationMethodType
   ): zio.IO[AuthenticationRepositoryError, Unit]
 
-  def deleteByEntityIdAndTypeAndSecret(
+  def delete(
       entityId: UUID,
       amt: AuthenticationMethodType,
       secret: String

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/AuthenticationRepository.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/AuthenticationRepository.scala
@@ -7,52 +7,79 @@ import zio.IO
 import zio.*
 import zio.interop.catz.*
 
+import java.time.OffsetDateTime
 import java.util.UUID
 
 enum AuthenticationMethodType(val value: String) {
   case ApiKey extends AuthenticationMethodType("apikey")
 }
 
+object AuthenticationMethodType {
+  def fromString(value: String) = {
+    AuthenticationMethodType.values.find(_.value == value).get
+  }
+}
+
 case class AuthenticationMethod(
-    id: UUID,
     `type`: AuthenticationMethodType,
     entityId: UUID,
-    secret: String
-)
+    secret: String,
+    createdAt: OffsetDateTime = OffsetDateTime.now(),
+    deletedAt: Option[OffsetDateTime] = None
+) {
+  def isDeleted = deletedAt.isDefined
+}
 
 trait AuthenticationRepository {
   def insert(
       entityId: UUID,
-      authenticationMethod: AuthenticationMethodType,
+      amt: AuthenticationMethodType,
       secret: String
-  ): zio.IO[AuthenticationRepositoryError, UUID]
-
-  def getEntityIdByMethodAndSecret(
-      method: AuthenticationMethodType,
-      secret: String
-  ): zio.IO[AuthenticationRepositoryError, UUID]
-
-  def deleteById(id: UUID): zio.IO[AuthenticationRepositoryError, Unit]
-
-  def deleteByMethodAndEntityId(
-      method: AuthenticationMethodType,
-      entityId: UUID
   ): zio.IO[AuthenticationRepositoryError, Unit]
 
-  def deleteByEntityIdAndSecret(id: UUID, secret: String): zio.IO[AuthenticationRepositoryError, Unit]
+  def getEntityIdByMethodAndSecret(
+      amt: AuthenticationMethodType,
+      secret: String
+  ): zio.IO[AuthenticationRepositoryError, UUID]
+
+  def findAuthenticationMethodByTypeAndSecret(
+      amt: AuthenticationMethodType,
+      secret: String
+  ): zio.IO[AuthenticationRepositoryError, Option[AuthenticationMethod]]
+
+  def deleteByMethodAndEntityId(
+      entityId: UUID,
+      amt: AuthenticationMethodType
+  ): zio.IO[AuthenticationRepositoryError, Unit]
+
+  def deleteByEntityIdAndTypeAndSecret(
+      entityId: UUID,
+      amt: AuthenticationMethodType,
+      secret: String
+  ): zio.IO[AuthenticationRepositoryError, Unit]
 }
 
-type AuthenticationMethodConfiguration = zio.json.ast.Json
-
+//TODO: reconsider the hierarchy of the service and dal layers
 sealed trait AuthenticationRepositoryError {
   def message: String
 }
 
 object AuthenticationRepositoryError {
+
+  def hide(secret: String) = secret.take(8) + "****"
   case class AuthenticationNotFound(authenticationMethodType: AuthenticationMethodType, secret: String)
       extends AuthenticationRepositoryError {
     def message =
-      s"Authentication method not found for type ${authenticationMethodType.value} and secret $secret"
+      s"Authentication method not found for type:${authenticationMethodType.value} and secret:${hide(secret)}"
+  }
+
+  case class AuthenticationCompromised(
+      entityId: UUID,
+      authenticationMethodType: AuthenticationMethodType,
+      secret: String
+  ) extends AuthenticationRepositoryError {
+    def message =
+      s"Authentication method is compromised for entityId:$entityId, type:${authenticationMethodType.value}, and secret:${hide(secret)}"
   }
 
   case class ServiceError(message: String) extends AuthenticationRepositoryError
@@ -71,52 +98,61 @@ object AuthenticationRepositorySql extends DoobieContext.Postgres(SnakeCase) wit
     MappedEncoding[AuthenticationMethodType, String](_.value)
 
   implicit val string2AuthenticationMethodType: MappedEncoding[String, AuthenticationMethodType] =
-    MappedEncoding[String, AuthenticationMethodType](str => AuthenticationMethodType.valueOf(str))
+    MappedEncoding[String, AuthenticationMethodType](AuthenticationMethodType.fromString)
 
   def insert(authenticationMethod: AuthenticationMethod) = {
     run {
       quote {
-        query[AuthenticationMethod].insertValue(lift(authenticationMethod)).returning(_.id)
+        query[AuthenticationMethod].insertValue(lift(authenticationMethod))
       }
     }
   }
 
-  def getEntityIdByMethodAndSecret(method: AuthenticationMethodType, secret: String) = {
+  def getEntityIdByMethodAndSecret(amt: AuthenticationMethodType, secret: String) = {
     run {
       quote {
         query[AuthenticationMethod]
-          .filter(am => am.secret == lift(secret) && am.`type` == lift(method))
+          .filter(am => am.secret == lift(secret) && am.`type` == lift(amt) && am.deletedAt.isEmpty)
           .map(_.entityId)
           .take(1)
       }
     }
   }
 
-  def deleteById(id: UUID) = {
-    run {
-      quote {
-        query[AuthenticationMethod].filter(_.id == lift(id)).delete
-      }
-    }
-  }
-
-  def deleteByMethodAndEntityId(method: AuthenticationMethodType, entityId: UUID) = {
-    run {
-      quote {
-        query[AuthenticationMethod].filter(am => am.`type` == lift(method) && am.entityId == lift(entityId)).delete
-      }
-    }
-  }
-
-  def deleteByEntityIdAndSecret(entityId: UUID, secret: String) = {
+  def filterByTypeAndSecret(amt: AuthenticationMethodType, secret: String) = {
     run {
       quote {
         query[AuthenticationMethod]
-          .filter(am =>
-            am.entityId == lift(entityId) &&
-              am.secret == lift(secret)
-          )
-          .delete
+          .filter(am => am.secret == lift(secret) && am.`type` == lift(amt))
+      }
+    }
+  }
+
+  def softDeleteByEntityIdAndType(
+      entityId: UUID,
+      amt: AuthenticationMethodType,
+      deletedAt: Option[OffsetDateTime]
+  ) = {
+    run {
+      quote {
+        query[AuthenticationMethod]
+          .filter(am => am.`type` == lift(amt) && am.entityId == lift(entityId))
+          .update(_.deletedAt -> lift(deletedAt))
+      }
+    }
+  }
+
+  def softDeleteBy(
+      entityId: UUID,
+      amt: AuthenticationMethodType,
+      secret: String,
+      deletedAt: Option[OffsetDateTime]
+  ) = {
+    run {
+      quote {
+        query[AuthenticationMethod]
+          .filter(am => am.entityId == lift(entityId) && am.`type` == lift(amt) && am.secret == lift(secret))
+          .update(_.deletedAt -> lift(deletedAt))
       }
     }
   }

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/JdbcAuthenticationRepository.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/JdbcAuthenticationRepository.scala
@@ -2,9 +2,11 @@ package io.iohk.atala.iam.authentication.apikey
 
 import doobie.*
 import doobie.implicits.*
+import org.postgresql.util.PSQLException
 import zio.*
 import zio.interop.catz.*
 
+import java.time.OffsetDateTime
 import java.util.UUID
 
 case class JdbcAuthenticationRepository(xa: Transactor[Task]) extends AuthenticationRepository {
@@ -12,23 +14,87 @@ case class JdbcAuthenticationRepository(xa: Transactor[Task]) extends Authentica
   import AuthenticationRepositorySql.*
   override def insert(
       entityId: UUID,
-      authenticationMethodType: AuthenticationMethodType,
+      amt: AuthenticationMethodType,
       secret: String
-  ): IO[AuthenticationRepositoryError, UUID] = {
-    val authenticationMethod = AuthenticationMethod(UUID.randomUUID(), authenticationMethodType, entityId, secret)
+  ): IO[AuthenticationRepositoryError, Unit] = {
+    val authenticationMethod = AuthenticationMethod(amt, entityId, secret)
     AuthenticationRepositorySql
       .insert(authenticationMethod)
       .transact(xa)
+      .map(_ => ())
       .logError(
-        s"insert failed for entityId: $entityId, authenticationMethod: $authenticationMethod, and secret: $secret"
+        s"insert failed for entityId: $entityId, authenticationMethodType: $amt, and secret: $secret"
       )
-      .mapError(AuthenticationRepositoryError.StorageError.apply)
+      .mapError {
+        case sqlException: PSQLException
+            if sqlException.getMessage
+              .contains("ERROR: duplicate key value violates unique constraint \"unique_type_secret_constraint\"") =>
+          AuthenticationRepositoryError.AuthenticationCompromised(entityId, amt, secret)
+        case otherSqlException: PSQLException =>
+          AuthenticationRepositoryError.StorageError(otherSqlException)
+        case unexpected: Throwable =>
+          AuthenticationRepositoryError.UnexpectedError(unexpected)
+      }
+      .catchSome { case ac @ AuthenticationRepositoryError.AuthenticationCompromised(entityId, amt, secret) =>
+        val failure: IO[AuthenticationRepositoryError, Unit] = ZIO.fail(ac)
+        deleteByEntityIdAndTypeAndSecret(entityId, amt, secret).map(_ => ()) *> failure
+      }
   }
 
   override def getEntityIdByMethodAndSecret(
-      method: AuthenticationMethodType,
+      amt: AuthenticationMethodType,
       secret: String
   ): IO[AuthenticationRepositoryError, UUID] = {
+    AuthenticationRepositorySql
+      .getEntityIdByMethodAndSecret(amt, secret)
+      .transact(xa)
+      .logError(s"getEntityIdByMethodAndSecret failed for method: $amt and secret: $secret")
+      .mapError(AuthenticationRepositoryError.StorageError.apply)
+      .flatMap(
+        _.headOption.fold(ZIO.fail(AuthenticationRepositoryError.AuthenticationNotFound(amt, secret)))(entityId =>
+          ZIO.succeed(entityId)
+        )
+      )
+  }
+
+  override def findAuthenticationMethodByTypeAndSecret(
+      amt: AuthenticationMethodType,
+      secret: String
+  ): IO[AuthenticationRepositoryError, Option[AuthenticationMethod]] = {
+    AuthenticationRepositorySql
+      .filterByTypeAndSecret(amt, secret)
+      .transact(xa)
+      .logError(s"findAuthenticationMethodBySecret failed for secret:$secret")
+      .map(_.headOption)
+      .mapError(AuthenticationRepositoryError.StorageError.apply)
+  }
+
+  override def deleteByMethodAndEntityId(
+      entityId: UUID,
+      amt: AuthenticationMethodType
+  ): IO[AuthenticationRepositoryError, Unit] = {
+    AuthenticationRepositorySql
+      .softDeleteByEntityIdAndType(entityId, amt, Some(OffsetDateTime.now()))
+      .transact(xa)
+      .logError(s"deleteByMethodAndEntityId failed for method: $amt and entityId: $entityId")
+      .mapError(AuthenticationRepositoryError.StorageError.apply)
+      .map(_ => ())
+  }
+
+  override def deleteByEntityIdAndTypeAndSecret(
+      entityId: UUID,
+      amt: AuthenticationMethodType,
+      secret: String
+  ): IO[AuthenticationRepositoryError, Unit] = {
+    AuthenticationRepositorySql
+      .softDeleteBy(entityId, amt, secret, Some(OffsetDateTime.now()))
+      .transact(xa)
+      .logError(s"deleteByEntityIdAndSecret failed for id: $entityId and secret: $secret")
+      .mapError(AuthenticationRepositoryError.StorageError.apply)
+      .map(_ => ())
+  }
+
+  def checkDeleted(method: AuthenticationMethodType, secret: String) = {
     AuthenticationRepositorySql
       .getEntityIdByMethodAndSecret(method, secret)
       .transact(xa)
@@ -39,36 +105,6 @@ case class JdbcAuthenticationRepository(xa: Transactor[Task]) extends Authentica
           ZIO.succeed(entityId)
         )
       )
-  }
-
-  override def deleteById(id: UUID): IO[AuthenticationRepositoryError, Unit] = {
-    AuthenticationRepositorySql
-      .deleteById(id)
-      .transact(xa)
-      .logError(s"deleteById failed for id: $id")
-      .mapError(AuthenticationRepositoryError.StorageError.apply)
-      .map(_ => ())
-  }
-
-  override def deleteByMethodAndEntityId(
-      method: AuthenticationMethodType,
-      entityId: UUID
-  ): IO[AuthenticationRepositoryError, Unit] = {
-    AuthenticationRepositorySql
-      .deleteByMethodAndEntityId(method, entityId)
-      .transact(xa)
-      .logError(s"deleteByMethodAndEntityId failed for method: $method and entityId: $entityId")
-      .mapError(AuthenticationRepositoryError.StorageError.apply)
-      .map(_ => ())
-  }
-
-  override def deleteByEntityIdAndSecret(id: UUID, secret: String): IO[AuthenticationRepositoryError, Unit] = {
-    AuthenticationRepositorySql
-      .deleteByEntityIdAndSecret(id, secret)
-      .transact(xa)
-      .logError(s"deleteByEntityIdAndSecret failed for id: $id and secret: $secret")
-      .mapError(AuthenticationRepositoryError.StorageError.apply)
-      .map(_ => ())
   }
 }
 

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/entity/http/model/ApiKeyAuthenticationRequest.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/entity/http/model/ApiKeyAuthenticationRequest.scala
@@ -2,7 +2,7 @@ package io.iohk.atala.iam.entity.http.model
 
 import io.iohk.atala.api.http.Annotation
 import io.iohk.atala.iam.entity.http.model.ApiKeyAuthenticationRequest.annotations
-import sttp.tapir.Schema
+import sttp.tapir.{Schema, Validator}
 import sttp.tapir.Schema.annotations.{description, encodedExample, validate, validateEach}
 import sttp.tapir.Validator.*
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
@@ -15,7 +15,7 @@ case class ApiKeyAuthenticationRequest(
     entityId: UUID,
     @description(annotations.apikey.description)
     @encodedExample(annotations.apikey.example)
-    @validate(nonEmptyString)
+    @validate(all(minLength(16), maxLength(128)))
     apiKey: String
 )
 

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyAuthenticatorSpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyAuthenticatorSpec.scala
@@ -15,6 +15,7 @@ import io.iohk.atala.iam.authentication.AuthenticationError
 import io.iohk.atala.iam.authentication.AuthenticationError.InvalidCredentials
 import io.iohk.atala.shared.models.WalletId
 import io.iohk.atala.shared.test.containers.PostgresTestContainerSupport
+import zio.Runtime.removeDefaultLoggers
 import zio.test.Assertion.*
 import zio.test.TestAspect.sequential
 import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assert, *}
@@ -67,7 +68,9 @@ object ApiKeyAuthenticatorSpec extends ZIOSpecDefault, PostgresTestContainerSupp
       paths = "classpath:sql/agent"
     )
 
-    testSuite.provideSomeLayerShared(testEnvironmentLayer)
+    testSuite
+      .provideSomeLayerShared(testEnvironmentLayer)
+      .provide(removeDefaultLoggers)
   }
 
   val failWhenTheHeaderIsAnEmptyStringTest = test("should fail when the header is empty string")(

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/iam/authentication/apikey/JdbcAuthenticationRepositorySpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/iam/authentication/apikey/JdbcAuthenticationRepositorySpec.scala
@@ -7,6 +7,7 @@ import zio.test.*
 import zio.test.TestAspect.*
 import zio.test.Assertion.*
 import io.iohk.atala.container.util.MigrationAspects.migrate
+import io.iohk.atala.iam.authentication.apikey.AuthenticationMethodType.ApiKey
 import zio.Runtime.removeDefaultLoggers
 
 object JdbcAuthenticationRepositorySpec extends ZIOSpecDefault, PostgresTestContainerSupport {
@@ -44,12 +45,12 @@ object JdbcAuthenticationRepositorySpec extends ZIOSpecDefault, PostgresTestCont
           assert(notFoundEntityId)(isSubtype[AuthenticationRepositoryError.AuthenticationNotFound](anything))
       }
     },
-    test("insert a similar secret must fail") {
-      check(entityIdAndSecretGen) { case (entityId, secret) =>
+    test("insert a similar secret for a different tenant must fail") {
+      check(entityIdAndSecretGen <*> entityIdGen) { case (entityId, secret, anotherEntityId) =>
         for {
           repository <- ZIO.service[AuthenticationRepository]
           _ <- repository.insert(entityId, AuthenticationMethodType.ApiKey, secret)
-          insertSameSecret <- repository.insert(entityId, AuthenticationMethodType.ApiKey, secret).flip
+          insertSameSecret <- repository.insert(anotherEntityId, AuthenticationMethodType.ApiKey, secret).flip
           authenticationMethod <- repository
             .findAuthenticationMethodByTypeAndSecret(AuthenticationMethodType.ApiKey, secret)
         } yield assert(insertSameSecret)(
@@ -58,6 +59,34 @@ object JdbcAuthenticationRepositorySpec extends ZIOSpecDefault, PostgresTestCont
           assert(authenticationMethod)(isSome(anything)) &&
           assert(authenticationMethod.flatMap(_.deletedAt))(isSome(anything))
       }
+    },
+    test("insert a similar secret for the same tenant must succeed") {
+      check(entityIdAndSecretGen) { case (entityId, secret) =>
+        for {
+          repository <- ZIO.service[AuthenticationRepository]
+          _ <- repository.insert(entityId, AuthenticationMethodType.ApiKey, secret)
+          _ <- repository.insert(entityId, AuthenticationMethodType.ApiKey, secret)
+          authenticationMethod <- repository
+            .findAuthenticationMethodByTypeAndSecret(AuthenticationMethodType.ApiKey, secret)
+        } yield assert(authenticationMethod)(isSome(anything)) &&
+          assert(authenticationMethod.flatMap(_.deletedAt))(isNone)
+      }
+    },
+    test("insert a similar secret after deletion for the same tenant must fail") {
+      check(entityIdAndSecretGen) { case (entityId, secret) =>
+        for {
+          repository <- ZIO.service[AuthenticationRepository]
+          _ <- repository.insert(entityId, ApiKey, secret)
+          _ <- repository.delete(entityId, ApiKey, secret)
+          insertSameSecret <- repository.insert(entityId, ApiKey, secret).flip
+          authenticationMethod <- repository
+            .findAuthenticationMethodByTypeAndSecret(ApiKey, secret)
+        } yield assert(insertSameSecret)(
+          isSubtype[AuthenticationRepositoryError.AuthenticationCompromised](anything)
+        ) &&
+          assert(authenticationMethod)(isSome(anything)) &&
+          assert(authenticationMethod.flatMap(_.deletedAt))(isSome(anything))
+      }
     }
-  ) @@ samples(1) @@ nondeterministic
+  ) @@ samples(10) @@ nondeterministic
 }

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/iam/authentication/apikey/JdbcAuthenticationRepositorySpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/iam/authentication/apikey/JdbcAuthenticationRepositorySpec.scala
@@ -2,14 +2,18 @@ package io.iohk.atala.iam.authentication.apikey
 
 import io.iohk.atala.shared.test.containers.PostgresTestContainerSupport
 import zio.test.{TestAspect, ZIOSpecDefault}
-
 import zio.ZIO
 import zio.test.*
 import zio.test.TestAspect.*
 import zio.test.Assertion.*
 import io.iohk.atala.container.util.MigrationAspects.migrate
+import zio.Runtime.removeDefaultLoggers
 
 object JdbcAuthenticationRepositorySpec extends ZIOSpecDefault, PostgresTestContainerSupport {
+
+  val entityIdGen = Gen.uuid
+  val secretGen = Gen.alphaNumericStringBounded(256, 256)
+  val entityIdAndSecretGen = entityIdGen <*> secretGen
 
   override def spec = {
     val testSuite =
@@ -20,23 +24,40 @@ object JdbcAuthenticationRepositorySpec extends ZIOSpecDefault, PostgresTestCont
         paths = "classpath:sql/agent"
       )
 
-    testSuite.provideSomeLayerShared(
-      pgContainerLayer >+> systemTransactorLayer >+> JdbcAuthenticationRepository.layer
-    )
+    testSuite
+      .provideSomeLayerShared(
+        pgContainerLayer >+> systemTransactorLayer >+> JdbcAuthenticationRepository.layer
+      )
+      .provide(removeDefaultLoggers)
   }
 
   private val crudSpec = suite("CRUD operations on the AuthenticationRepository")(
     test("create, read, update, delete") {
-      check(Gen.uuid <*> Gen.alphaNumericStringBounded(256, 256)) { case (entityId, secret) =>
+      check(entityIdAndSecretGen) { case (entityId, secret) =>
         for {
           repository <- ZIO.service[AuthenticationRepository]
           recordId <- repository.insert(entityId, AuthenticationMethodType.ApiKey, secret)
           fetchedEntityId <- repository.getEntityIdByMethodAndSecret(AuthenticationMethodType.ApiKey, secret)
-          _ <- repository.deleteByMethodAndEntityId(AuthenticationMethodType.ApiKey, entityId)
+          _ <- repository.deleteByMethodAndEntityId(entityId, AuthenticationMethodType.ApiKey)
           notFoundEntityId <- repository.getEntityIdByMethodAndSecret(AuthenticationMethodType.ApiKey, secret).flip
         } yield assert(entityId)(equalTo(fetchedEntityId)) &&
           assert(notFoundEntityId)(isSubtype[AuthenticationRepositoryError.AuthenticationNotFound](anything))
       }
+    },
+    test("insert a similar secret must fail") {
+      check(entityIdAndSecretGen) { case (entityId, secret) =>
+        for {
+          repository <- ZIO.service[AuthenticationRepository]
+          _ <- repository.insert(entityId, AuthenticationMethodType.ApiKey, secret)
+          insertSameSecret <- repository.insert(entityId, AuthenticationMethodType.ApiKey, secret).flip
+          authenticationMethod <- repository
+            .findAuthenticationMethodByTypeAndSecret(AuthenticationMethodType.ApiKey, secret)
+        } yield assert(insertSameSecret)(
+          isSubtype[AuthenticationRepositoryError.AuthenticationCompromised](anything)
+        ) &&
+          assert(authenticationMethod)(isSome(anything)) &&
+          assert(authenticationMethod.flatMap(_.deletedAt))(isSome(anything))
+      }
     }
-  ) @@ samples(100) @@ nondeterministic
+  ) @@ samples(1) @@ nondeterministic
 }

--- a/prism-agent/service/wallet-api/src/main/resources/sql/agent/V13__apikey_authentication_improvements.sql
+++ b/prism-agent/service/wallet-api/src/main/resources/sql/agent/V13__apikey_authentication_improvements.sql
@@ -1,0 +1,11 @@
+ALTER TABLE public.authentication_method
+    DROP COLUMN id;
+
+ALTER TABLE public.authentication_method
+    ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE public.authentication_method
+    ADD COLUMN deleted_at TIMESTAMPTZ DEFAULT NULL;
+
+ALTER TABLE public.authentication_method
+    ADD CONSTRAINT unique_type_secret_constraint UNIQUE (type, secret);

--- a/tests/e2e-tests/src/test/kotlin/common/Environments.kt
+++ b/tests/e2e-tests/src/test/kotlin/common/Environments.kt
@@ -3,7 +3,7 @@ package common
 object Environments {
     val AGENT_AUTH_REQUIRED: Boolean = (System.getenv("AGENT_AUTH_REQUIRED") ?: "true").toBoolean()
     val AGENT_AUTH_HEADER = System.getenv("AGENT_AUTH_HEADER") ?: "apikey"
-    val ACME_AUTH_KEY = System.getenv("ACME_AUTH_KEY") ?: "ACME_AUTH_KEY"
+    val ACME_AUTH_KEY = System.getenv("ACME_AUTH_KEY") ?: "SECURE_ACME_AUTH_KEY_GREATER_16_SYMBOLS"
     val ACME_AGENT_URL = System.getenv("ACME_AGENT_URL") ?: "http://localhost:8080/prism-agent"
     val ACME_AGENT_WEBHOOK_HOST = System.getenv("ACME_AGENT_WEBHOOK_HOST") ?: "host.docker.internal"
     val ACME_AGENT_WEBHOOK_PORT = (System.getenv("ACME_AGENT_WEBHOOK_PORT") ?: "9955").toInt()
@@ -14,7 +14,7 @@ object Environments {
     val BOB_AGENT_WEBHOOK_PORT = (System.getenv("BOB_AGENT_WEBHOOK_PORT") ?: "9956").toInt()
     val BOB_AGENT_WEBHOOK_URL = "http://$BOB_AGENT_WEBHOOK_HOST:$BOB_AGENT_WEBHOOK_PORT"
     val FABER_AGENT_URL = System.getenv("FABER_AGENT_URL") ?: "http://localhost:8080/prism-agent"
-    val FABER_AUTH_KEY = System.getenv("FABER_AUTH_KEY") ?: "FABER_AUTH_KEY"
+    val FABER_AUTH_KEY = System.getenv("FABER_AUTH_KEY") ?: "SECURE_FABER_AUTH_KEY_GREATER_16_SYMBOLS"
     val FABER_AGENT_WEBHOOK_HOST = System.getenv("FABER_AGENT_WEBHOOK_HOST") ?: "host.docker.internal"
     val FABER_AGENT_WEBHOOK_PORT = (System.getenv("FABER_AGENT_WEBHOOK_PORT") ?: "9957").toInt()
     val FABER_AGENT_WEBHOOK_URL = "http://$FABER_AGENT_WEBHOOK_HOST:$FABER_AGENT_WEBHOOK_PORT"

--- a/tests/e2e-tests/src/test/kotlin/features/multitenancy/EntitySteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/multitenancy/EntitySteps.kt
@@ -2,9 +2,12 @@ package features.multitenancy
 
 import api_models.CreateEntityRequest
 import api_models.AddApiKeyRequest
+import common.Ensure
 import common.Utils
 import interactions.Post
+import net.serenitybdd.rest.SerenityRest
 import net.serenitybdd.screenplay.Actor
+import org.apache.http.HttpStatus.SC_CREATED
 import java.util.*
 
 class EntitySteps {
@@ -26,6 +29,9 @@ class EntitySteps {
                     )
                 },
         )
+        actor.attemptsTo(
+            Ensure.that(SerenityRest.lastResponse().statusCode).isEqualTo(SC_CREATED)
+        )
         return Utils.lastResponseObject("id", String::class)
     }
 
@@ -40,6 +46,9 @@ class EntitySteps {
                         )
                     )
                 },
+        )
+        actor.attemptsTo(
+            Ensure.that(SerenityRest.lastResponse().statusCode).isEqualTo(SC_CREATED)
         )
     }
 }


### PR DESCRIPTION
# Overview
Code cleanup
APIKEY logic doesn't allow to use the same apikey

Fixes ATL-5768

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [x] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [x] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [x] My changes can and should be tested by unit and/or integration tests
* [x] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
