### PR TITLE
docs: replace broken link in Issue.md, AnonCreds Credential definition

### DIFF
--- a/docs/docusaurus/credentials/issue.md
+++ b/docs/docusaurus/credentials/issue.md
@@ -124,7 +124,7 @@ curl -X 'POST' \
 
 1. `claims`: The data stored in a verifiable credential. AnonCreds claims get expressed in a flat, "string -> string", key-value pair format. The claims contain the data that the issuer attests to, such as name, address, date of birth, and so on.
 2. `connectionId`: The unique ID of the connection between the holder and the issuer to offer this credential over.
-3. `credentialDefinitionId`: The unique ID of the [credential definition](../credentialdefinition/credential-definition.md) that has been created by the issuer as a prerequisite. Please refer to the [Create AnonCreds Credential Definition](../credential-definitions/credential-definitions.md) doc for details on how to create a credential definition.
+3. `credentialDefinitionId`: The unique ID of the [credential definition](../credentialdefinition/credential-definition.md) that has been created by the issuer as a prerequisite. Please refer to the [Create AnonCreds Credential Definition](../credential-definition/credential-definition.md) doc for details on how to create a credential definition.
 4. `credentialFormat`: The format of the credential that will be issued - `AnonCreds` in this case.  
 
 :::note


### PR DESCRIPTION
# Overview
Replacing a broken link in documentation which is breaking the docs CI build due to an invalid link.

Fixes https://input-output.atlassian.net/browse/ATL-5875 CI task from not being able to complete.

## Checklist

### My PR contains...
* [x] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
