### PR TITLE
fix: check for active RLS on db application user

### DIFF
--- a/connect/lib/sql-doobie/src/main/scala/io/iohk/atala/connect/sql/repository/Migrations.scala
+++ b/connect/lib/sql-doobie/src/main/scala/io/iohk/atala/connect/sql/repository/Migrations.scala
@@ -3,7 +3,9 @@ package io.iohk.atala.connect.sql.repository
 import doobie.*
 import doobie.implicits.*
 import doobie.util.transactor.Transactor
+import io.iohk.atala.shared.db.ContextAwareTask
 import io.iohk.atala.shared.db.DbConfig
+import io.iohk.atala.shared.db.Implicits.*
 import org.flywaydb.core.Flyway
 import zio.*
 import zio.interop.catz.*
@@ -34,6 +36,23 @@ final case class Migrations(config: DbConfig) {
 object Migrations {
   val layer: URLayer[DbConfig, Migrations] =
     ZLayer.fromFunction(Migrations.apply _)
+
+  /** Fail if the RLS is not enabled from a sample table */
+  def validateRLS: RIO[Transactor[ContextAwareTask], Unit] = {
+    val cxnIO = sql"""
+      | SELECT row_security_active('public.connection_records');
+      """.stripMargin
+      .query[Boolean]
+      .unique
+
+    for {
+      xa <- ZIO.service[Transactor[ContextAwareTask]]
+      isRlsActive <- cxnIO.transactWithoutContext(xa)
+      _ <- ZIO
+        .fail(Exception("The RLS policy is not active for Connect DB application user"))
+        .unless(isRlsActive)
+    } yield ()
+  }
 
   def initDbPrivileges(appUser: String): RIO[Transactor[Task], Unit] = {
     val cxnIO = for {

--- a/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/service/MockCredentialService.scala
+++ b/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/service/MockCredentialService.scala
@@ -6,7 +6,7 @@ import io.iohk.atala.mercury.model.DidId
 import io.iohk.atala.mercury.protocol.issuecredential.{IssueCredential, OfferCredential, RequestCredential}
 import io.iohk.atala.pollux.core.model.error.CredentialServiceError
 import io.iohk.atala.pollux.core.model.{DidCommID, IssueCredentialRecord}
-import io.iohk.atala.pollux.vc.jwt.{Issuer, W3cCredentialPayload}
+import io.iohk.atala.pollux.vc.jwt.{W3cCredentialPayload}
 import io.iohk.atala.prism.crypto.MerkleInclusionProof
 import io.iohk.atala.shared.models.WalletAccessContext
 import zio.mock.{Mock, Proxy}

--- a/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/service/MockCredentialService.scala
+++ b/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/service/MockCredentialService.scala
@@ -6,7 +6,7 @@ import io.iohk.atala.mercury.model.DidId
 import io.iohk.atala.mercury.protocol.issuecredential.{IssueCredential, OfferCredential, RequestCredential}
 import io.iohk.atala.pollux.core.model.error.CredentialServiceError
 import io.iohk.atala.pollux.core.model.{DidCommID, IssueCredentialRecord}
-import io.iohk.atala.pollux.vc.jwt.{W3cCredentialPayload}
+import io.iohk.atala.pollux.vc.jwt.W3cCredentialPayload
 import io.iohk.atala.prism.crypto.MerkleInclusionProof
 import io.iohk.atala.shared.models.WalletAccessContext
 import zio.mock.{Mock, Proxy}

--- a/pollux/lib/sql-doobie/src/main/scala/io/iohk/atala/pollux/sql/repository/Migrations.scala
+++ b/pollux/lib/sql-doobie/src/main/scala/io/iohk/atala/pollux/sql/repository/Migrations.scala
@@ -3,7 +3,9 @@ package io.iohk.atala.pollux.sql.repository
 import doobie.*
 import doobie.implicits.*
 import doobie.util.transactor.Transactor
+import io.iohk.atala.shared.db.ContextAwareTask
 import io.iohk.atala.shared.db.DbConfig
+import io.iohk.atala.shared.db.Implicits.*
 import org.flywaydb.core.Flyway
 import zio.*
 import zio.interop.catz.*
@@ -35,6 +37,23 @@ final case class Migrations(config: DbConfig) {
 object Migrations {
   val layer: URLayer[DbConfig, Migrations] =
     ZLayer.fromFunction(Migrations.apply _)
+
+  /** Fail if the RLS is not enabled from a sample table */
+  def validateRLS: RIO[Transactor[ContextAwareTask], Unit] = {
+    val cxnIO = sql"""
+      | SELECT row_security_active('public.credential_schema');
+      """.stripMargin
+      .query[Boolean]
+      .unique
+
+    for {
+      xa <- ZIO.service[Transactor[ContextAwareTask]]
+      isRlsActive <- cxnIO.transactWithoutContext(xa)
+      _ <- ZIO
+        .fail(Exception("The RLS policy is not active for Pollux DB application user"))
+        .unless(isRlsActive)
+    } yield ()
+  }
 
   def initDbPrivileges(appUser: String): RIO[Transactor[Task], Unit] = {
     val cxnIO = for {

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Main.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Main.scala
@@ -78,6 +78,10 @@ object MainApp extends ZIOAppDefault {
     _ <- ZIO.serviceWithZIO[PolluxMigrations](_.migrate)
     _ <- ZIO.serviceWithZIO[ConnectMigrations](_.migrate)
     _ <- ZIO.serviceWithZIO[AgentMigrations](_.migrate)
+    _ <- ZIO.logInfo("Running post-migration RLS checks for DB application users")
+    _ <- PolluxMigrations.validateRLS.provide(RepoModule.polluxContextAwareTransactorLayer)
+    _ <- ConnectMigrations.validateRLS.provide(RepoModule.connectContextAwareTransactorLayer)
+    _ <- AgentMigrations.validateRLS.provide(RepoModule.agentContextAwareTransactorLayer)
   } yield ()
 
   override def run: ZIO[Any, Throwable, Unit] = {

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
@@ -23,7 +23,6 @@ import io.iohk.atala.agent.walletapi.vault.{
   VaultWalletSecretStorage
 }
 import io.iohk.atala.castor.core.service.DIDService
-import io.iohk.atala.iam.authentication.DefaultAuthenticator
 import io.iohk.atala.iam.authentication.admin.AdminApiKeyAuthenticator
 import io.iohk.atala.iam.authentication.admin.AdminApiKeyAuthenticatorImpl
 import io.iohk.atala.iam.authentication.admin.AdminConfig

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/http/ZHttpEndpoints.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/http/ZHttpEndpoints.scala
@@ -1,6 +1,5 @@
 package io.iohk.atala.agent.server.http
 
-import io.iohk.atala.iam.authentication.oidc.JwtSecurityLogic
 import sttp.apispec.SecurityScheme
 import sttp.apispec.openapi.{OpenAPI, Server}
 import sttp.model.headers.AuthenticationScheme


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Fixes ATL-5793. Check for active RLS after running migration and fail during startup if RLS is not active.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
