### PR TITLE
fix(prism-agent): perform percent encoding on auth header for token introspection request

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/oidc/KeycloakClient.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/oidc/KeycloakClient.scala
@@ -7,6 +7,8 @@ import zio.*
 import zio.http.*
 import zio.json.*
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import scala.jdk.CollectionConverters.*
 
 final case class TokenIntrospection(active: Boolean, sub: Option[String])
@@ -61,7 +63,10 @@ class KeycloakClientImpl(client: AuthzClient, httpClient: Client, keycloakConfig
           url = introspectionUrl,
           method = Method.POST,
           headers = baseFormHeaders ++ Headers(
-            Header.Authorization.Basic(keycloakConfig.clientId, keycloakConfig.clientSecret)
+            Header.Authorization.Basic(
+              username = URLEncoder.encode(keycloakConfig.clientId, StandardCharsets.UTF_8),
+              password = URLEncoder.encode(keycloakConfig.clientSecret, StandardCharsets.UTF_8)
+            )
           ),
           content = Body.fromURLEncodedForm(
             Form(


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

When making a request where Basic auth credential contains special character, it will fail with invalid credential. Credential should be encoded before sending.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
