### PR TITLE
fix(pollux): V16 migration is failing to add FK constraint because of type mismatch

### DIFF
--- a/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V16__revocation_status_lists_table_and_columns.sql
+++ b/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V16__revocation_status_lists_table_and_columns.sql
@@ -16,7 +16,11 @@ CREATE TABLE public.credential_status_lists
     updated_at   TIMESTAMP WITH TIME ZONE                   NOT NULL default now()
 );
 
-CREATE INDEX credential_status_lists_wallet_id_index ON public.credential_revocation_status_lists (wallet_id);
+CREATE INDEX credential_status_lists_wallet_id_index ON public.credential_status_lists (wallet_id)
+
+ALTER TABLE public.issue_credential_records
+    ALTER COLUMN id TYPE UUID USING id::uuid;
+
 
 CREATE TABLE public.credentials_in_status_list
 (

--- a/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V16__revocation_status_lists_table_and_columns.sql
+++ b/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V16__revocation_status_lists_table_and_columns.sql
@@ -18,14 +18,11 @@ CREATE TABLE public.credential_status_lists
 
 CREATE INDEX credential_status_lists_wallet_id_index ON public.credential_status_lists (wallet_id);
 
-ALTER TABLE public.issue_credential_records
-    ALTER COLUMN id TYPE UUID USING id::uuid;
-
 
 CREATE TABLE public.credentials_in_status_list
 (
     id                         UUID PRIMARY KEY                  default gen_random_uuid(),
-    issue_credential_record_id UUID                     NOT NULL,
+    issue_credential_record_id VARCHAR(64)              NOT NULL,
     credential_status_list_id  UUID                     NOT NULL,
     status_list_index          INTEGER                  NOT NULL,
 --  is revoked or suspended

--- a/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V16__revocation_status_lists_table_and_columns.sql
+++ b/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V16__revocation_status_lists_table_and_columns.sql
@@ -16,7 +16,7 @@ CREATE TABLE public.credential_status_lists
     updated_at   TIMESTAMP WITH TIME ZONE                   NOT NULL default now()
 );
 
-CREATE INDEX credential_status_lists_wallet_id_index ON public.credential_status_lists (wallet_id)
+CREATE INDEX credential_status_lists_wallet_id_index ON public.credential_status_lists (wallet_id);
 
 ALTER TABLE public.issue_credential_records
     ALTER COLUMN id TYPE UUID USING id::uuid;


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

fix migration V16 by altering a data type `issue_credential_record_id` in `credentials_in_status_list` from UUID to varchar(64)

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [x] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [x] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
