### PR TITLE
fix: change admin auth priority and improve auth error message

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/SecurityLogic.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/SecurityLogic.scala
@@ -68,7 +68,7 @@ object SecurityLogic {
       authenticator: Authenticator[E],
       authorizer: Authorizer[E]
   ): IO[ErrorResponse, (BaseEntity, WalletAdministrationContext)] =
-    authenticate[E](credentials._3, credentials._2, credentials._1)(authenticator)
+    authenticate[E](credentials._1, credentials._3, credentials._2)(authenticator)
       .flatMap {
         case Left(entity)  => authorizeWalletAdmin(entity)(EntityAuthorizer).map(entity -> _)
         case Right(entity) => authorizeWalletAdmin(entity)(authorizer).map(entity -> _)

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/wallet/http/controller/WalletManagementController.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/wallet/http/controller/WalletManagementController.scala
@@ -5,6 +5,7 @@ import io.iohk.atala.agent.walletapi.model.Wallet
 import io.iohk.atala.agent.walletapi.model.WalletSeed
 import io.iohk.atala.agent.walletapi.service.WalletManagementService
 import io.iohk.atala.agent.walletapi.service.WalletManagementServiceError
+import io.iohk.atala.agent.walletapi.service.WalletManagementServiceError.TooManyPermittedWallet
 import io.iohk.atala.api.http.ErrorResponse
 import io.iohk.atala.api.http.RequestContext
 import io.iohk.atala.api.http.model.CollectionStats
@@ -18,13 +19,12 @@ import io.iohk.atala.iam.wallet.http.model.WalletDetail
 import io.iohk.atala.iam.wallet.http.model.WalletDetailPage
 import io.iohk.atala.shared.models.HexString
 import io.iohk.atala.shared.models.WalletAdministrationContext
+import io.iohk.atala.shared.models.WalletAdministrationContext.Admin
 import io.iohk.atala.shared.models.WalletId
 import zio.*
 
 import java.util.UUID
 import scala.language.implicitConversions
-import io.iohk.atala.agent.walletapi.service.WalletManagementServiceError.TooManyPermittedWallet
-import io.iohk.atala.shared.models.WalletAdministrationContext.Admin
 
 trait WalletManagementController {
   def listWallet(


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

ATL-6210
ATL-6211

- AdminApiKey have the highest priority
- Improve auth error message by excluding `MethodNotEnabled`

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [x] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
