### PR TITLE
build: make sbt-license-report more fault tolerance with dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -408,24 +408,7 @@ publish / skip := true
 val commonSetttings = Seq(
   testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
   // Needed for Kotlin coroutines that support new memory management mode
-  resolvers += "JetBrains Space Maven Repository" at "https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven",
-  updateLicenses := {
-    if (name.value == "sharedtest") {
-      val resolveReport = ivyModule.value.withModule(streams.value.log) { (ivy, desc, _) =>
-        // https://github.com/sbt/sbt-license-report/blob/5a8cb0b6567789bd8867e709b0cad8bb93aca50f/src/main/scala/sbtlicensereport/license/LicenseReport.scala#L222
-        val resolveId = org.apache.ivy.core.resolve.ResolveOptions.getDefaultResolveId(desc)
-        val resolveOptions = new org.apache.ivy.core.resolve.ResolveOptions
-        resolveOptions.setResolveId(resolveId)
-        resolveOptions.setLog(org.apache.ivy.core.LogOptions.LOG_QUIET)
-        // skip transitive deps
-        resolveOptions.setTransitive(false)
-        ivy.resolve(desc, resolveOptions)
-      }
-      sbtlicensereport.license.LicenseReport(Nil, resolveReport)
-    } else {
-      updateLicenses.value
-    }
-  }
+  resolvers += "JetBrains Space Maven Repository" at "https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven"
 )
 
 // #####################

--- a/build.sbt
+++ b/build.sbt
@@ -409,6 +409,8 @@ val commonSetttings = Seq(
   testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
   // Needed for Kotlin coroutines that support new memory management mode
   resolvers += "JetBrains Space Maven Repository" at "https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven",
+  // Override 'updateLicenses' for all project to inject custom DependencyResolution.
+  // https://github.com/sbt/sbt-license-report/blob/9675cedb19c794de1119cbcf46a255fc8dcd5d4e/src/main/scala/sbtlicensereport/SbtLicenseReport.scala#L84
   updateLicenses := {
     import sbt.librarymanagement.DependencyResolution
     import sbt.librarymanagement.ivy.IvyDependencyResolution
@@ -418,9 +420,7 @@ val commonSetttings = Seq(
     val overrides = licenseOverrides.value.lift
     val depExclusions = licenseDepExclusions.value.lift
     val originatingModule = DepModuleInfo(organization.value, name.value, version.value)
-    val resolution = DependencyResolution(
-      new LicenseReportCustomDependencyResolution(IvyDependencyResolution(ivyConfiguration.value))
-    )
+    val resolution = DependencyResolution(new LicenseReportCustomDependencyResolution(ivyConfiguration.value, ivyModule.value))
     license.LicenseReport.makeReport(
       ivyModule.value,
       resolution,

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/iam/authentication/SecurityLogicSpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/iam/authentication/SecurityLogicSpec.scala
@@ -94,7 +94,6 @@ object SecurityLogicSpec extends ZIOSpecDefault {
               )
             )
           )
-          .debug("error")
           .exit
       } yield assert(exit)(fails(hasField("status", _.status, equalTo(sttp.model.StatusCode.Forbidden.code)))) &&
         assert(exit)(fails(hasField("detail", _.detail, isSome(equalTo("invalid credentials")))))

--- a/project/LicenseReport.scala
+++ b/project/LicenseReport.scala
@@ -1,70 +1,37 @@
-package io.iohk.atala.sbt
-
-import sbt.Keys._
-import sbt._
-import sbt.librarymanagement
+import sbt.Logger
 import sbt.librarymanagement._
-import sbt.librarymanagement.ivy.IvyDependencyResolution
-import sbtlicensereport.license
 
-/** A plugin which enables reporting on licensing used within a project. */
-object CustomSbtLicenseReport extends AutoPlugin {
-  import sbtlicensereport.SbtLicenseReport
+class LicenseReportCustomDependencyResolution(origResolution: DependencyResolution)
+    extends DependencyResolutionInterface {
 
-  override def requires: Plugins = SbtLicenseReport.requires
-  override def trigger = SbtLicenseReport.trigger
+  private val dummyFile = java.io.File.createTempFile("sbt-license-report", "")
+  private val dummyStat = UpdateStats(0, 0, 0, false)
+  private val dummyReport = UpdateReport(dummyFile, Vector.empty, dummyStat, Map.empty)
 
-  import SbtLicenseReport.autoImportImpl
-  val autoImport = autoImportImpl
-  import autoImport._
+  override def moduleDescriptor(moduleSetting: ModuleDescriptorConfiguration): ModuleDescriptor =
+    origResolution.moduleDescriptor(moduleSetting)
 
-  private class CustomResolution(origResolution: DependencyResolution, logger: Logger)
-      extends DependencyResolutionInterface {
-
-    private val dummyFile = java.io.File.createTempFile("sbt-license-report", "")
-    private val dummyStat = librarymanagement.UpdateStats(0, 0, 0, false)
-    private val dummyReport = librarymanagement.UpdateReport(dummyFile, Vector.empty, dummyStat, Map.empty)
-
-    override def moduleDescriptor(moduleSetting: ModuleDescriptorConfiguration): ModuleDescriptor =
-      origResolution.moduleDescriptor(moduleSetting)
-
-    override def update(
-        module: ModuleDescriptor,
-        configuration: UpdateConfiguration,
-        uwconfig: UnresolvedWarningConfiguration,
-        log: Logger
-    ): Either[UnresolvedWarning, UpdateReport] = {
-      log.error("using custom resolution update")
-      origResolution
-        .update(module, configuration, uwconfig, log)
-        .left
-        .flatMap(_ => Right(dummyReport))
-    }
+  override def update(
+      module: ModuleDescriptor,
+      configuration: UpdateConfiguration,
+      uwconfig: UnresolvedWarningConfiguration,
+      log: Logger
+  ): Either[UnresolvedWarning, UpdateReport] = {
+    origResolution
+      .update(module, configuration, uwconfig, Logger.Null)
+      .left
+      .flatMap { unresolved =>
+        log.warn(":::::::::::::::::::::::::::::::::::::::::::::::::::")
+        log.warn("::     LicenseReport Unresolved Dependencies     ::")
+        log.warn(":::::::::::::::::::::::::::::::::::::::::::::::::::")
+        unresolved.failedPaths
+          .flatMap(_.headOption)
+          .map { case (module, _) => module.toString() }
+          .sorted
+          .distinct
+          .foreach { module => log.warn(s":: $module") }
+        log.warn(":::::::::::::::::::::::::::::::::::::::::::::::::::")
+        Right(dummyReport)
+      }
   }
-
-  override lazy val projectSettings: Seq[Setting[_]] =
-    SbtLicenseReport.projectSettings ++
-      Seq(
-        updateLicenses := {
-          val ignore = update.value
-          val overrides = licenseOverrides.value.lift
-          val depExclusions = licenseDepExclusions.value.lift
-          val originatingModule = DepModuleInfo(organization.value, name.value, version.value)
-          val resolution = DependencyResolution(
-            new CustomResolution(IvyDependencyResolution(ivyConfiguration.value), streams.value.log)
-          )
-          license.LicenseReport.makeReport(
-            ivyModule.value,
-            resolution,
-            licenseConfigurations.value,
-            licenseSelection.value,
-            overrides,
-            depExclusions,
-            originatingModule,
-            streams.value.log
-          )
-        },
-      )
-
-  override lazy val globalSettings = SbtLicenseReport.globalSettings
 }

--- a/project/LicenseReport.scala
+++ b/project/LicenseReport.scala
@@ -1,0 +1,70 @@
+package io.iohk.atala.sbt
+
+import sbt.Keys._
+import sbt._
+import sbt.librarymanagement
+import sbt.librarymanagement._
+import sbt.librarymanagement.ivy.IvyDependencyResolution
+import sbtlicensereport.license
+
+/** A plugin which enables reporting on licensing used within a project. */
+object CustomSbtLicenseReport extends AutoPlugin {
+  import sbtlicensereport.SbtLicenseReport
+
+  override def requires: Plugins = SbtLicenseReport.requires
+  override def trigger = SbtLicenseReport.trigger
+
+  import SbtLicenseReport.autoImportImpl
+  val autoImport = autoImportImpl
+  import autoImport._
+
+  private class CustomResolution(origResolution: DependencyResolution, logger: Logger)
+      extends DependencyResolutionInterface {
+
+    private val dummyFile = java.io.File.createTempFile("sbt-license-report", "")
+    private val dummyStat = librarymanagement.UpdateStats(0, 0, 0, false)
+    private val dummyReport = librarymanagement.UpdateReport(dummyFile, Vector.empty, dummyStat, Map.empty)
+
+    override def moduleDescriptor(moduleSetting: ModuleDescriptorConfiguration): ModuleDescriptor =
+      origResolution.moduleDescriptor(moduleSetting)
+
+    override def update(
+        module: ModuleDescriptor,
+        configuration: UpdateConfiguration,
+        uwconfig: UnresolvedWarningConfiguration,
+        log: Logger
+    ): Either[UnresolvedWarning, UpdateReport] = {
+      log.error("using custom resolution update")
+      origResolution
+        .update(module, configuration, uwconfig, log)
+        .left
+        .flatMap(_ => Right(dummyReport))
+    }
+  }
+
+  override lazy val projectSettings: Seq[Setting[_]] =
+    SbtLicenseReport.projectSettings ++
+      Seq(
+        updateLicenses := {
+          val ignore = update.value
+          val overrides = licenseOverrides.value.lift
+          val depExclusions = licenseDepExclusions.value.lift
+          val originatingModule = DepModuleInfo(organization.value, name.value, version.value)
+          val resolution = DependencyResolution(
+            new CustomResolution(IvyDependencyResolution(ivyConfiguration.value), streams.value.log)
+          )
+          license.LicenseReport.makeReport(
+            ivyModule.value,
+            resolution,
+            licenseConfigurations.value,
+            licenseSelection.value,
+            overrides,
+            depExclusions,
+            originatingModule,
+            streams.value.log
+          )
+        },
+      )
+
+  override lazy val globalSettings = SbtLicenseReport.globalSettings
+}

--- a/project/LicenseReport.scala
+++ b/project/LicenseReport.scala
@@ -1,37 +1,63 @@
 import sbt.Logger
 import sbt.librarymanagement._
+import sbt.librarymanagement.ivy._
+import sbt.internal.librarymanagement.{IvySbt, IvyRetrieve}
 
-class LicenseReportCustomDependencyResolution(origResolution: DependencyResolution)
+// Since to ivy fails to resolve project dependencies, customized version is used to ignore any failure.
+// This is OK as we only grab license information from the resolution metadata,
+// and the faing dependencies are only used in 'Test' configuration.
+// This should be used until 'sbt-license-report' plugin use coursier to populate license.
+//
+// https://github.com/sbt/sbt-license-report/issues/47
+// https://github.com/sbt/sbt-license-report/issues/87
+class LicenseReportCustomDependencyResolution(ivyConfiguration: IvyConfiguration, ivyModule: IvySbt#Module)
     extends DependencyResolutionInterface {
 
+  private val ivyResolution = IvyDependencyResolution(ivyConfiguration)
   private val dummyFile = java.io.File.createTempFile("sbt-license-report", "")
-  private val dummyStat = UpdateStats(0, 0, 0, false)
-  private val dummyReport = UpdateReport(dummyFile, Vector.empty, dummyStat, Map.empty)
 
   override def moduleDescriptor(moduleSetting: ModuleDescriptorConfiguration): ModuleDescriptor =
-    origResolution.moduleDescriptor(moduleSetting)
+    ivyResolution.moduleDescriptor(moduleSetting)
 
+  // Resolve using low-level ivy directly to skip sbt-wrapped ivy failing the resolution and discard the UpdateReport.
+  // https://github.com/sbt/sbt-license-report/blob/5a8cb0b6567789bd8867e709b0cad8bb93aca50f/src/main/scala/sbtlicensereport/license/LicenseReport.scala#L221
   override def update(
       module: ModuleDescriptor,
       configuration: UpdateConfiguration,
       uwconfig: UnresolvedWarningConfiguration,
       log: Logger
   ): Either[UnresolvedWarning, UpdateReport] = {
-    origResolution
-      .update(module, configuration, uwconfig, Logger.Null)
-      .left
-      .flatMap { unresolved =>
-        log.warn(":::::::::::::::::::::::::::::::::::::::::::::::::::")
-        log.warn("::     LicenseReport Unresolved Dependencies     ::")
-        log.warn(":::::::::::::::::::::::::::::::::::::::::::::::::::")
-        unresolved.failedPaths
-          .flatMap(_.headOption)
-          .map { case (module, _) => module.toString() }
-          .sorted
-          .distinct
-          .foreach { module => log.warn(s":: $module") }
-        log.warn(":::::::::::::::::::::::::::::::::::::::::::::::::::")
-        Right(dummyReport)
-      }
+    val (resolveReport, err) = ivyModule.withModule(Logger.Null) { (ivy, desc, default) =>
+      import org.apache.ivy.core.resolve.ResolveOptions
+      val resolveOptions = new ResolveOptions
+      val resolveId = ResolveOptions.getDefaultResolveId(desc)
+      resolveOptions.setResolveId(resolveId)
+      import org.apache.ivy.core.LogOptions.LOG_QUIET
+      resolveOptions.setLog(LOG_QUIET)
+      val resolveReport = ivy.resolve(desc, resolveOptions)
+      val err =
+        if (resolveReport.hasError) {
+          val messages = resolveReport.getAllProblemMessages.toArray.map(_.toString).distinct
+          val failed = resolveReport.getUnresolvedDependencies.map(node => IvyRetrieve.toModuleID(node.getId))
+          Some(new ResolveException(messages, failed))
+        } else None
+      (resolveReport, err)
+    }
+
+    err.foreach { resolveException =>
+      log.warn(":::::::::::::::::::::::::::::::::::::::::::::::::::")
+      log.warn("::     LicenseReport Unresolved Dependencies     ::")
+      log.warn(":::::::::::::::::::::::::::::::::::::::::::::::::::")
+      resolveException
+        .failed
+        .map(_.toString())
+        .distinct
+        .sorted
+        .foreach { module => log.warn(s":: $module") }
+      log.warn(":::::::::::::::::::::::::::::::::::::::::::::::::::")
+    }
+
+    val updateReport = IvyRetrieve.updateReport(resolveReport, dummyFile)
+    Right(updateReport)
   }
 }

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,0 +1,3 @@
+lazy val sbtLicenseReport = ProjectRef(uri("https://github.com/sbt/sbt-license-report.git#9675cedb19c794de1119cbcf46a255fc8dcd5d4e"), "sbt-license-report")
+
+lazy val root = (project in file(".")).dependsOn(sbtLicenseReport)

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,4 @@
-lazy val sbtLicenseReport = ProjectRef(uri("https://github.com/sbt/sbt-license-report.git#9675cedb19c794de1119cbcf46a255fc8dcd5d4e"), "sbt-license-report")
+// Using unreleased plugin from 'main' which accepts DependencyResolution interface for building license report.
+lazy val sbtLicenseReportPlugin = ProjectRef(uri("https://github.com/sbt/sbt-license-report.git#9675cedb19c794de1119cbcf46a255fc8dcd5d4e"), "sbt-license-report")
 
-lazy val root = (project in file(".")).dependsOn(sbtLicenseReport)
+lazy val root = (project in file(".")).dependsOn(sbtLicenseReportPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,6 @@ addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.6")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.9")
-addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 
 // In order to import proper version of com.google.protobuf.ByteString we need to add this dependency


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Fixes ATL-6173

Upgrade new version of `sbt-license-report` plugin that provides `DependencyResolution` interface. Override that interface with an implementation that will not fail when resolving license information.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
