### PR TITLE
feat: add nodeAffinity, tolerations, and resources to k8s deployment

### DIFF
--- a/infrastructure/charts/agent/templates/deployment.yaml
+++ b/infrastructure/charts/agent/templates/deployment.yaml
@@ -212,6 +212,9 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
       {{- if .Values.server.keycloak.bootstrap }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
       volumes:
       - name: keycloak-bootstrap-script
         configMap:

--- a/infrastructure/charts/agent/templates/deployment.yaml
+++ b/infrastructure/charts/agent/templates/deployment.yaml
@@ -212,9 +212,6 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
       {{- if .Values.server.keycloak.bootstrap }}
-      affinity:
-        {{- toYaml .Values.affinity | nindent 8 }}
-      tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
       volumes:
       - name: keycloak-bootstrap-script
         configMap:
@@ -224,3 +221,6 @@ spec:
           - key: "init.sh"
             path: "init.sh"
       {{- end }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 8 }}

--- a/infrastructure/charts/agent/templates/postgresql.yaml
+++ b/infrastructure/charts/agent/templates/postgresql.yaml
@@ -10,6 +10,12 @@ spec:
   volume:
     size: "{{ .Values.database.postgres.databaseSize }}"
   numberOfInstances: {{ .Values.database.postgres.numberOfInstances }}
+  nodeAffinity:
+    {{- toYaml .Values.affinity.nodeAffinity | nindent 4 }}
+  tolerations:
+    {{- toYaml .Values.tolerations | nindent 4 }}
+  resources:
+    {{- toYaml .Values.database.postgres.resources | nindent 4 }}
   users:
     pollux-admin:
       - superuser

--- a/infrastructure/charts/agent/values.yaml
+++ b/infrastructure/charts/agent/values.yaml
@@ -52,6 +52,13 @@ database:
     managingTeam: atala
     databaseSize: 4Gi
     numberOfInstances: 2
+    resources:
+      requests:
+        cpu: 10m
+        memory: 100Mi
+      limits:
+        cpu: 500m
+        memory: 500Mi
 
 vdrManager:
   host: chart-base-node-service
@@ -134,3 +141,20 @@ keycloak:
   - name: prism-agent-realm-import-volume
     mountPath: /opt/bitnami/keycloak/data/import
     readOnly: true
+
+# It is configured for deployment and postgresql objects of prism-agent
+affinity:
+  nodeAffinity: {}
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#      nodeSelectorTerms:
+#        - matchExpressions:
+#            - key: "performance"
+#              operator: In
+#              values:
+#                - "true"
+
+tolerations: {}
+#  - key: "type"
+#    operator: "Equal"
+#    value: "performance"
+#    effect: "NoSchedule"


### PR DESCRIPTION
# Overview
Adding option to specify nodeAffinity, tolerations, and resources for prism-agent deployment and postgresql objects which will allows us to schedule pods to dedicated nodepools using these parameters.
Examples are provided in `values.yaml`
Fixes ATL-5538

## Checklist

### My PR contains...
* [x] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
