### PR TITLE
feat: add configuration for gRPC usePlainText (enable TLS for gRPC)

### DIFF
--- a/prism-agent/service/server/src/main/resources/application.conf
+++ b/prism-agent/service/server/src/main/resources/application.conf
@@ -4,7 +4,7 @@ prismNode {
     host = ${?PRISM_NODE_HOST}
     port = 50053
     port = ${?PRISM_NODE_PORT}
-    usePlainText = false
+    usePlainText = true
     usePlainText = ${?PRISM_NODE_USE_PLAIN_TEXT}
   }
 }

--- a/prism-agent/service/server/src/main/resources/application.conf
+++ b/prism-agent/service/server/src/main/resources/application.conf
@@ -4,6 +4,8 @@ prismNode {
     host = ${?PRISM_NODE_HOST}
     port = 50053
     port = ${?PRISM_NODE_PORT}
+    usePlainText = false
+    usePlainText = ${?PRISM_NODE_USE_PLAIN_TEXT}
   }
 }
 

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
@@ -127,7 +127,7 @@ object GrpcModule {
         .map(_.prismNode.service)
         .flatMap(config =>
           ZIO.attempt(
-            NodeServiceGrpc.stub(ManagedChannelBuilder.forAddress(config.host, config.port).usePlaintext.build)
+            NodeServiceGrpc.stub(ManagedChannelBuilder.forAddress(config.host, config.port).build)
           )
         )
     )

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
@@ -126,9 +126,15 @@ object GrpcModule {
         .service[AppConfig]
         .map(_.prismNode.service)
         .flatMap(config =>
-          ZIO.attempt(
-            NodeServiceGrpc.stub(ManagedChannelBuilder.forAddress(config.host, config.port).build)
-          )
+          if (config.usePlainText) {
+            ZIO.attempt(
+              NodeServiceGrpc.stub(ManagedChannelBuilder.forAddress(config.host, config.port).usePlaintext().build)
+            )
+          } else {
+            ZIO.attempt(
+              NodeServiceGrpc.stub(ManagedChannelBuilder.forAddress(config.host, config.port).build)
+            )
+          }
         )
     )
     SystemModule.configLayer >>> stubLayer

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
@@ -128,7 +128,7 @@ object GrpcModule {
         .flatMap(config =>
           if (config.usePlainText) {
             ZIO.attempt(
-              NodeServiceGrpc.stub(ManagedChannelBuilder.forAddress(config.host, config.port).usePlaintext().build)
+              NodeServiceGrpc.stub(ManagedChannelBuilder.forAddress(config.host, config.port).usePlaintext.build)
             )
           } else {
             ZIO.attempt(

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/config/AppConfig.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/config/AppConfig.scala
@@ -48,7 +48,7 @@ final case class ConnectConfig(
 
 final case class PrismNodeConfig(service: GrpcServiceConfig)
 
-final case class GrpcServiceConfig(host: String, port: Int)
+final case class GrpcServiceConfig(host: String, port: Int, usePlainText: Boolean)
 
 final case class DatabaseConfig(
     host: String,


### PR DESCRIPTION
# Overview

Previously, connecting to PRISM Node over gRPC was hardcoded to be insecure and over plaintext

Now, the default is still insecure but can be configured at run time with an environment variable

In future - this should be made secure by default but would be a breaking change and needs to be managed as such

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [x] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [x] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
