### PR TITLE
fix: remove oas schema format for empty repsonse body

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/api/http/codec/DIDCodec.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/api/http/codec/DIDCodec.scala
@@ -18,9 +18,9 @@ object DIDCodec {
 
   def emptyDidJsonLD: Codec[String, DIDResolutionResult, DIDJsonLD] =
     didJsonLD.schema(_ =>
-      Schema.schemaForByteArray
+      Schema.schemaForString
         .description("Empty representation")
-        .encodedExample(Array.emptyByteArray)
+        .encodedExample("")
         .as
     )
 


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Update tapir definition so that it doesn't render this
```
type: string
format: binary
```

## Checklist

### My PR contains...
* [x] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [x] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
