### PR TITLE
feat(agent): make the connection pool size configurable, fixes #913

### DIFF
--- a/prism-agent/service/server/src/main/resources/application.conf
+++ b/prism-agent/service/server/src/main/resources/application.conf
@@ -25,7 +25,8 @@ pollux {
     appUsername = ${?POLLUX_DB_APP_USER}
     appPassword = "password"
     appPassword = ${?POLLUX_DB_APP_PASSWORD}
-    awaitConnectionThreads = 8
+    awaitConnectionThreads = 4
+    awaitConnectionThreads = ${?POLLUX_DB_AWAIT_CONNECTION_THREADS}
   }
   issueBgJobRecordsLimit = 25
   issueBgJobRecordsLimit = ${?ISSUE_BG_JOB_RECORDS_LIMIT}
@@ -57,7 +58,8 @@ connect {
     appUsername = ${?CONNECT_DB_APP_USER}
     appPassword = "password"
     appPassword = ${?CONNECT_DB_APP_PASSWORD}
-    awaitConnectionThreads = 8
+    awaitConnectionThreads = 4
+    awaitConnectionThreads = ${?CONNECT_DB_AWAIT_CONNECTION_THREADS}
   }
   connectBgJobRecordsLimit = 25
   connectBgJobRecordsLimit = ${?CONNECT_BG_JOB_RECORDS_LIMIT}
@@ -164,7 +166,8 @@ agent {
         appUsername = ${?AGENT_DB_APP_USER}
         appPassword = "password"
         appPassword = ${?AGENT_DB_APP_PASSWORD}
-        awaitConnectionThreads = 8
+        awaitConnectionThreads = 4
+        awaitConnectionThreads = ${?AGENT_DB_AWAIT_CONNECTION_THREADS}
     }
     verification {
         options {


### PR DESCRIPTION
### Description: 
Make the Postgresql connection pool size configurable and reduce the default number from 8 to 4

### Checklist: 
- [x] My PR follows the contribution guidelines of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
