### PR TITLE
fix: allow configurable path convention for vault secrets

### DIFF
--- a/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/service/CredentialDefinitionServiceImpl.scala
+++ b/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/service/CredentialDefinitionServiceImpl.scala
@@ -34,8 +34,8 @@ class CredentialDefinitionServiceImpl(
   override def create(in: CredentialDefinition.Input): Result[CredentialDefinition] = {
     for {
       uri <- ZIO.attempt(new URI(in.schemaId))
-      content <- uriDereferencer.dereference(uri).debug("content")
-      anoncredSchema <- AnoncredSchemaSerDesV1.schemaSerDes.deserialize(content).debug("anoncredSchema")
+      content <- uriDereferencer.dereference(uri)
+      anoncredSchema <- AnoncredSchemaSerDesV1.schemaSerDes.deserialize(content)
       anoncredLibSchema =
         AnoncredSchemaDef(
           in.schemaId,

--- a/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/service/CredentialDefinitionServiceImpl.scala
+++ b/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/service/CredentialDefinitionServiceImpl.scala
@@ -34,8 +34,8 @@ class CredentialDefinitionServiceImpl(
   override def create(in: CredentialDefinition.Input): Result[CredentialDefinition] = {
     for {
       uri <- ZIO.attempt(new URI(in.schemaId))
-      content <- uriDereferencer.dereference(uri)
-      anoncredSchema <- AnoncredSchemaSerDesV1.schemaSerDes.deserialize(content)
+      content <- uriDereferencer.dereference(uri).debug("content")
+      anoncredSchema <- AnoncredSchemaSerDesV1.schemaSerDes.deserialize(content).debug("anoncredSchema")
       anoncredLibSchema =
         AnoncredSchemaDef(
           in.schemaId,

--- a/prism-agent/service/server/src/main/resources/application.conf
+++ b/prism-agent/service/server/src/main/resources/application.conf
@@ -203,8 +203,8 @@ agent {
             address = "http://localhost:8200"
             address = ${?VAULT_ADDR}
 
-            # Store secret in Vault with meaningful convention for path segments.
-            # Can be disabled for fixed-length secret path if vault backend has low limit for length.
+            # Store secrets in Vault with meaningful convention for path segments.
+            # Can be disabled for fixed-length secret path if vault storage backend has small limit for path length.
             useSemanticPath = true
             useSemanticPath = ${?VAULT_USE_SEMANTIC_PATH}
 

--- a/prism-agent/service/server/src/main/resources/application.conf
+++ b/prism-agent/service/server/src/main/resources/application.conf
@@ -203,6 +203,11 @@ agent {
             address = "http://localhost:8200"
             address = ${?VAULT_ADDR}
 
+            # Store secret in Vault with meaningful convention for path segments.
+            # Can be disabled for fixed-length secret path if vault backend has low limit for length.
+            useSemanticPath = true
+            useSemanticPath = ${?VAULT_USE_SEMANTIC_PATH}
+
             # Vault token authentication.
             # Can be omitted if other authentication mechanism is provided.
             token = ${?VAULT_TOKEN}

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
@@ -225,7 +225,7 @@ object RepoModule {
       } yield vaultKVClient
     }
 
-    SystemModule.configLayer >>> vaultClient
+    SystemModule.configLayer ++ SystemModule.zioHttpClientLayer >>> vaultClient
   }
 
   val allSecretStorageLayer: TaskLayer[DIDSecretStorage & WalletSecretStorage & GenericSecretStorage] = {

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
@@ -232,35 +232,38 @@ object RepoModule {
     ZLayer.fromZIO {
       ZIO
         .service[AppConfig]
-        .map(_.agent.secretStorage.backend)
-        .tap(backend => ZIO.logInfo(s"Using '$backend' as a secret storage backend"))
-        .flatMap {
-          case SecretStorageBackend.vault =>
-            ZIO.succeed(
-              ZLayer.make[DIDSecretStorage & WalletSecretStorage & GenericSecretStorage](
-                VaultDIDSecretStorage.layer,
-                VaultWalletSecretStorage.layer,
-                VaultGenericSecretStorage.layer,
-                vaultClientLayer,
+        .map(_.agent.secretStorage)
+        .tap(conf => ZIO.logInfo(s"Using '${conf.backend}' as a secret storage backend"))
+        .flatMap { conf =>
+          val useSemanticPath = conf.vault.map(_.useSemanticPath).getOrElse(true)
+          conf.backend match {
+            case SecretStorageBackend.vault =>
+              ZIO.succeed(
+                ZLayer.make[DIDSecretStorage & WalletSecretStorage & GenericSecretStorage](
+                  VaultDIDSecretStorage.layer(useSemanticPath),
+                  VaultGenericSecretStorage.layer(useSemanticPath),
+                  VaultWalletSecretStorage.layer,
+                  vaultClientLayer,
+                )
               )
-            )
-          case SecretStorageBackend.postgres =>
-            ZIO.succeed(
-              ZLayer.make[DIDSecretStorage & WalletSecretStorage & GenericSecretStorage](
-                JdbcDIDSecretStorage.layer,
-                JdbcWalletSecretStorage.layer,
-                JdbcGenericSecretStorage.layer,
-                agentContextAwareTransactorLayer,
+            case SecretStorageBackend.postgres =>
+              ZIO.succeed(
+                ZLayer.make[DIDSecretStorage & WalletSecretStorage & GenericSecretStorage](
+                  JdbcDIDSecretStorage.layer,
+                  JdbcGenericSecretStorage.layer,
+                  JdbcWalletSecretStorage.layer,
+                  agentContextAwareTransactorLayer,
+                )
               )
-            )
-          case SecretStorageBackend.memory =>
-            ZIO.succeed(
-              ZLayer.make[DIDSecretStorage & WalletSecretStorage & GenericSecretStorage](
-                DIDSecretStorageInMemory.layer,
-                WalletSecretStorageInMemory.layer,
-                GenericSecretStorageInMemory.layer
+            case SecretStorageBackend.memory =>
+              ZIO.succeed(
+                ZLayer.make[DIDSecretStorage & WalletSecretStorage & GenericSecretStorage](
+                  DIDSecretStorageInMemory.layer,
+                  GenericSecretStorageInMemory.layer,
+                  WalletSecretStorageInMemory.layer,
+                )
               )
-            )
+          }
         }
         .provide(SystemModule.configLayer)
     }.flatten

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/config/AppConfig.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/config/AppConfig.scala
@@ -31,7 +31,8 @@ final case class VaultConfig(
     address: String,
     token: Option[String],
     appRoleRoleId: Option[String],
-    appRoleSecretId: Option[String]
+    appRoleSecretId: Option[String],
+    useSemanticPath: Boolean
 ) {
   def validate: Either[String, ValidatedVaultConfig] =
     val tokenConfig = token.map(ValidatedVaultConfig.TokenAuth(address, _))

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/agent/server/AgentInitializationSpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/agent/server/AgentInitializationSpec.scala
@@ -1,7 +1,6 @@
 package io.iohk.atala.agent.server
 
 import io.iohk.atala.agent.server.config.AppConfig
-import io.iohk.atala.agent.server.config.VaultConfig
 import io.iohk.atala.agent.walletapi.crypto.ApolloSpecHelper
 import io.iohk.atala.agent.walletapi.service.EntityServiceImpl
 import io.iohk.atala.agent.walletapi.service.WalletManagementService

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/agent/server/config/AppConfigSpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/agent/server/config/AppConfigSpec.scala
@@ -14,6 +14,7 @@ object AppConfigSpec extends ZIOSpecDefault {
     token = None,
     appRoleRoleId = None,
     appRoleSecretId = None,
+    useSemanticPath = true,
   )
 
   override def spec = suite("AppConfigSpec")(

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultClient.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultClient.scala
@@ -2,6 +2,7 @@ package io.iohk.atala.agent.walletapi.vault
 
 import io.github.jopenlibs.vault.Vault
 import io.github.jopenlibs.vault.VaultConfig
+import io.github.jopenlibs.vault.VaultException
 import io.github.jopenlibs.vault.api.Logical
 import io.github.jopenlibs.vault.api.LogicalUtilities
 import io.github.jopenlibs.vault.response.LogicalResponse
@@ -11,8 +12,6 @@ import zio.json.*
 
 import java.nio.charset.StandardCharsets
 import scala.jdk.CollectionConverters.*
-import sttp.model.StatusCode
-import io.github.jopenlibs.vault.VaultException
 
 trait VaultKVClient {
   def get[T: KVCodec](path: String): Task[Option[T]]

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultClient.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultClient.scala
@@ -211,7 +211,7 @@ object VaultKVClientImpl {
                 .flatMap { body =>
                   ZIO.fail(
                     VaultException(
-                      s"Expecting HTTP status 2xx, but instead receiving ${resp.status.code}. Response body: ${body}",
+                      s"Expecting HTTP status 2xx, but instead receiving ${resp.status.code}.\n Response body: ${body}",
                       resp.status.code
                     )
                   )

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultClient.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultClient.scala
@@ -2,23 +2,26 @@ package io.iohk.atala.agent.walletapi.vault
 
 import io.github.jopenlibs.vault.Vault
 import io.github.jopenlibs.vault.VaultConfig
+import io.github.jopenlibs.vault.api.Logical
+import io.github.jopenlibs.vault.api.LogicalUtilities
 import io.github.jopenlibs.vault.response.LogicalResponse
 import zio.*
+import zio.http.*
 
 import java.nio.charset.StandardCharsets
 import scala.jdk.CollectionConverters.*
 
 trait VaultKVClient {
   def get[T: KVCodec](path: String): Task[Option[T]]
-  def set[T: KVCodec](path: String, data: T): Task[Unit]
+  def set[T: KVCodec](path: String, data: T, customMetadata: Map[String, String] = Map.empty): Task[Unit]
 }
 
-class VaultKVClientImpl(vaultRef: Ref[Vault]) extends VaultKVClient {
+class VaultKVClientImpl(vaultRef: Ref[(Vault, VaultConfig)], client: Client) extends VaultKVClient {
   import VaultKVClientImpl.*
 
   override def get[T: KVCodec](path: String): Task[Option[T]] = {
     for {
-      vault <- vaultRef.get
+      vault <- vaultRef.get.map(_._1)
       maybeData <- ZIO
         .attemptBlocking(
           vault
@@ -31,10 +34,11 @@ class VaultKVClientImpl(vaultRef: Ref[Vault]) extends VaultKVClient {
     } yield decodedData
   }
 
-  override def set[T: KVCodec](path: String, data: T): Task[Unit] = {
+  override def set[T: KVCodec](path: String, data: T, customMetadata: Map[String, String]): Task[Unit] = {
     val kv = summon[KVCodec[T]].encode(data)
     for {
-      vault <- vaultRef.get
+      vault <- vaultRef.get.map(_._1)
+      vaultConfig <- vaultRef.get.map(_._2)
       _ <- ZIO
         .attemptBlocking {
           vault
@@ -42,26 +46,30 @@ class VaultKVClientImpl(vaultRef: Ref[Vault]) extends VaultKVClient {
             .write(path, kv.asJava)
         }
         .handleVaultError("Error writing a secret to Vault.")
+      _ <- ExtendedLogical(vaultConfig, client)
+        .writeMetadata(path, customMetadata)
+        .when(customMetadata.nonEmpty)
     } yield ()
   }
-
 }
 
 object VaultKVClientImpl {
 
   private final case class TokenRefreshState(leaseDuration: Duration)
 
-  def fromToken(address: String, token: String): Task[VaultKVClient] =
+  def fromToken(address: String, token: String): RIO[Client, VaultKVClient] =
     for {
+      client <- ZIO.service[Client]
       vault <- createVaultInstance(address, Some(token))
       vaultRef <- Ref.make(vault)
-    } yield VaultKVClientImpl(vaultRef)
+    } yield VaultKVClientImpl(vaultRef, client)
 
-  def fromAppRole(address: String, roleId: String, secretId: String): Task[VaultKVClient] =
+  def fromAppRole(address: String, roleId: String, secretId: String): RIO[Client, VaultKVClient] =
     for {
+      client <- ZIO.service[Client]
       vault <- createVaultInstance(address)
-      vaultRef <- vaultTokenRefreshLogic(vault, address, roleId, secretId)
-    } yield VaultKVClientImpl(vaultRef)
+      vaultRef <- vaultTokenRefreshLogic(vault._1, address, roleId, secretId)
+    } yield VaultKVClientImpl(vaultRef, client)
 
   private def vaultTokenRefreshLogic(
       authVault: Vault,
@@ -70,7 +78,7 @@ object VaultKVClientImpl {
       secretId: String,
       tokenRefreshBuffer: Duration = 15.seconds,
       retrySchedule: Schedule[Any, Any, Any] = Schedule.spaced(5.second) && Schedule.recurs(10)
-  ): Task[Ref[Vault]] = {
+  ): Task[Ref[(Vault, VaultConfig)]] = {
     val getToken = ZIO
       .attempt {
         val authResponse = authVault.auth().loginByAppRole(roleId, secretId)
@@ -100,13 +108,14 @@ object VaultKVClientImpl {
     } yield vaultRef
   }
 
-  private def createVaultInstance(address: String, token: Option[String] = None): Task[Vault] =
+  private def createVaultInstance(address: String, token: Option[String] = None): Task[(Vault, VaultConfig)] =
     ZIO.attempt {
-      val config = VaultConfig()
+      val configBuilder = VaultConfig()
         .engineVersion(2)
         .address(address)
-      token.foreach(config.token)
-      Vault.create(config.build())
+      token.foreach(configBuilder.token)
+      val config = configBuilder.build()
+      Vault.create(config) -> config
     }
 
   extension [R](resp: RIO[R, LogicalResponse]) {
@@ -147,4 +156,35 @@ object VaultKVClientImpl {
     }
   }
 
+  private[vault] class ExtendedLogical(config: VaultConfig, client: Client) extends Logical(config) {
+    // based on https://github.com/jopenlibs/vault-java-driver/blob/e49312a8cbcd14b260dacb2822c19223feb1b7af/src/main/java/io/github/jopenlibs/vault/api/Logical.java#L275
+    def writeMetadata(path: String, metadata: Map[String, String]): Task[Unit] = {
+      val pathSegments = path.split("/")
+      val pathDepth = config.getPrefixPathDepth()
+      val adjustedPath = LogicalUtilities.addQualifierToPath(pathSegments.toSeq.asJava, pathDepth, "metadata")
+      val url = config.getAddress() + "/v1/" + adjustedPath
+
+      for {
+        url <- ZIO.fromEither(URL.decode(url)).orDie
+        response <- ZIO.scoped {
+          client
+            .request(
+              Request(
+                url = url,
+                method = Method.POST,
+                headers = Headers(
+                  Header.Custom("X-Vault-Token", config.getToken()),
+                  Header.Custom("X-Vault-Namespace", config.getNameSpace()),
+                  Header.Custom("X-Vault-Request", "true"),
+                )
+              )
+            )
+            .retry(
+              Schedule.recurs(config.getMaxRetries()) &&
+                Schedule.spaced(config.getRetryIntervalMilliseconds().millis)
+            )
+        }
+      } yield ()
+    }
+  }
 }

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultClient.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultClient.scala
@@ -218,7 +218,6 @@ object VaultKVClientImpl {
                 }
             }
           }
-          .debug("writeMetadata")
           .retry {
             val maxRetry = Option(config.getMaxRetries()).getOrElse(0)
             val retryIntervalMillis = Option(config.getRetryIntervalMilliseconds()).getOrElse(0)

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultDIDSecretStorage.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultDIDSecretStorage.scala
@@ -45,5 +45,6 @@ class VaultDIDSecretStorage(vaultKV: VaultKVClient, useSemanticPath: Boolean) ex
 }
 
 object VaultDIDSecretStorage {
-  def layer: URLayer[VaultKVClient, DIDSecretStorage] = ZLayer.fromFunction(VaultDIDSecretStorage(_, true))
+  def layer(useSemanticPath: Boolean): URLayer[VaultKVClient, DIDSecretStorage] =
+    ZLayer.fromFunction(VaultDIDSecretStorage(_, useSemanticPath))
 }

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultDIDSecretStorage.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultDIDSecretStorage.scala
@@ -39,11 +39,11 @@ class VaultDIDSecretStorage(vaultKV: VaultKVClient, useSemanticPath: Boolean) ex
       s"$basePath/$relativePath" -> Map.empty
     } else {
       val relativePathHash = Sha256.compute(relativePath.getBytes(StandardCharsets.UTF_8)).getHexValue()
-      s"$basePath/$relativePathHash" -> Map(RELATIVE_PATH_METADATA_KEY -> relativePath)
+      s"$basePath/$relativePathHash" -> Map(SEMANTIC_PATH_METADATA_KEY -> relativePath)
     }
   }
 }
 
 object VaultDIDSecretStorage {
-  def layer: URLayer[VaultKVClient, DIDSecretStorage] = ZLayer.fromFunction(VaultDIDSecretStorage(_, false))
+  def layer: URLayer[VaultKVClient, DIDSecretStorage] = ZLayer.fromFunction(VaultDIDSecretStorage(_, true))
 }

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultDIDSecretStorage.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultDIDSecretStorage.scala
@@ -32,6 +32,7 @@ class VaultDIDSecretStorage(vaultKV: VaultKVClient, useSemanticPath: Boolean) ex
     } yield keyPair
   }
 
+  /** @return A tuple of secret path and a secret custom_metadata */
   private def peerDidKeyPath(walletId: WalletId)(did: DidId, keyId: String): (String, Map[String, String]) = {
     val basePath = s"${walletBasePath(walletId)}/dids/peer"
     val relativePath = s"${did.value}/keys/$keyId"

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultDIDSecretStorage.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultDIDSecretStorage.scala
@@ -33,13 +33,13 @@ class VaultDIDSecretStorage(vaultKV: VaultKVClient, useSemanticPath: Boolean) ex
   }
 
   private def peerDidKeyPath(walletId: WalletId)(did: DidId, keyId: String): (String, Map[String, String]) = {
-    val peerDidBasePath = s"${walletBasePath(walletId)}/dids/peer"
-    val peerDidRelPath = s"${did.value}/keys/$keyId"
+    val basePath = s"${walletBasePath(walletId)}/dids/peer"
+    val relativePath = s"${did.value}/keys/$keyId"
     if (useSemanticPath) {
-      s"$peerDidBasePath/$peerDidRelPath" -> Map.empty
+      s"$basePath/$relativePath" -> Map.empty
     } else {
-      val peerDidRelPathHash = Sha256.compute(peerDidRelPath.getBytes(StandardCharsets.UTF_8)).getHexValue()
-      s"$peerDidBasePath/$peerDidRelPathHash" -> Map(RELATIVE_PATH_METADATA_KEY -> peerDidRelPath)
+      val relativePathHash = Sha256.compute(relativePath.getBytes(StandardCharsets.UTF_8)).getHexValue()
+      s"$basePath/$relativePathHash" -> Map(RELATIVE_PATH_METADATA_KEY -> relativePath)
     }
   }
 }

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultDIDSecretStorage.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultDIDSecretStorage.scala
@@ -3,10 +3,10 @@ package io.iohk.atala.agent.walletapi.vault
 import com.nimbusds.jose.jwk.OctetKeyPair
 import io.iohk.atala.agent.walletapi.storage.DIDSecretStorage
 import io.iohk.atala.mercury.model.DidId
+import io.iohk.atala.prism.crypto.Sha256
 import io.iohk.atala.shared.models.WalletAccessContext
 import io.iohk.atala.shared.models.WalletId
 import zio.*
-import io.iohk.atala.prism.crypto.Sha256
 
 import java.nio.charset.StandardCharsets
 
@@ -18,7 +18,7 @@ class VaultDIDSecretStorage(vaultKV: VaultKVClient, useSemanticPath: Boolean) ex
       (path, metadata) = peerDidKeyPath(walletId)(did, keyId)
       alreadyExist <- vaultKV.get[OctetKeyPair](path).map(_.isDefined)
       _ <- vaultKV
-        .set[OctetKeyPair](path, keyPair)
+        .set[OctetKeyPair](path, keyPair, metadata)
         .when(!alreadyExist)
         .someOrFail(Exception(s"Secret on path $path already exists."))
     } yield 1

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultGenericSecretStorage.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultGenericSecretStorage.scala
@@ -43,12 +43,12 @@ class VaultGenericSecretStorage(vaultKV: VaultKVClient, useSemanticPath: Boolean
       s"$basePath/$relativePath" -> Map.empty
     } else {
       val relativePathHash = Sha256.compute(relativePath.getBytes(StandardCharsets.UTF_8)).getHexValue()
-      s"$basePath/$relativePathHash" -> Map(RELATIVE_PATH_METADATA_KEY -> relativePath)
+      s"$basePath/$relativePathHash" -> Map(SEMANTIC_PATH_METADATA_KEY -> relativePath)
     }
   }
 
 }
 
 object VaultGenericSecretStorage {
-  def layer: URLayer[VaultKVClient, GenericSecretStorage] = ZLayer.fromFunction(VaultGenericSecretStorage(_, false))
+  def layer: URLayer[VaultKVClient, GenericSecretStorage] = ZLayer.fromFunction(VaultGenericSecretStorage(_, true))
 }

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultGenericSecretStorage.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultGenericSecretStorage.scala
@@ -34,6 +34,7 @@ class VaultGenericSecretStorage(vaultKV: VaultKVClient, useSemanticPath: Boolean
     } yield result
   }
 
+  /** @return A tuple of secret path and a secret custom_metadata */
   private def constructKeyPath[K, V](
       walletId: WalletId
   )(key: K)(implicit ev: GenericSecret[K, V]): (String, Map[String, String]) = {

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultGenericSecretStorage.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/VaultGenericSecretStorage.scala
@@ -37,7 +37,7 @@ class VaultGenericSecretStorage(vaultKV: VaultKVClient, useSemanticPath: Boolean
   private def constructKeyPath[K, V](
       walletId: WalletId
   )(key: K)(implicit ev: GenericSecret[K, V]): (String, Map[String, String]) = {
-    val basePath = s"secret/${walletId.toUUID}/generic-secrets"
+    val basePath = s"${walletBasePath(walletId)}/generic-secrets"
     val relativePath = ev.keyPath(key)
     if (useSemanticPath) {
       s"$basePath/$relativePath" -> Map.empty
@@ -50,5 +50,6 @@ class VaultGenericSecretStorage(vaultKV: VaultKVClient, useSemanticPath: Boolean
 }
 
 object VaultGenericSecretStorage {
-  def layer: URLayer[VaultKVClient, GenericSecretStorage] = ZLayer.fromFunction(VaultGenericSecretStorage(_, true))
+  def layer(useSemanticPath: Boolean): URLayer[VaultKVClient, GenericSecretStorage] =
+    ZLayer.fromFunction(VaultGenericSecretStorage(_, useSemanticPath))
 }

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/package.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/package.scala
@@ -12,7 +12,7 @@ import scala.util.Failure
 import scala.util.Try
 
 package object vault {
-  val RELATIVE_PATH_METADATA_KEY: String = "relativePath"
+  val SEMANTIC_PATH_METADATA_KEY: String = "semanticPath"
 
   private[vault] def walletBasePath(walletId: WalletId): String = {
     s"secret/${walletId.toUUID}"

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/package.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/vault/package.scala
@@ -3,6 +3,7 @@ package io.iohk.atala.agent.walletapi
 import com.nimbusds.jose.jwk.OctetKeyPair
 import io.iohk.atala.agent.walletapi.model.WalletSeed
 import io.iohk.atala.shared.models.HexString
+import io.iohk.atala.shared.models.WalletId
 import zio.json.*
 import zio.json.ast.Json
 import zio.json.ast.Json.*
@@ -11,6 +12,12 @@ import scala.util.Failure
 import scala.util.Try
 
 package object vault {
+  val RELATIVE_PATH_METADATA_KEY: String = "relativePath"
+
+  private[vault] def walletBasePath(walletId: WalletId): String = {
+    s"secret/${walletId.toUUID}"
+  }
+
   trait KVCodec[T] {
     def encode(value: T): Map[String, String]
     def decode(kv: Map[String, String]): Try[T]

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/benchmark/KeyDerivation.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/benchmark/KeyDerivation.scala
@@ -38,7 +38,7 @@ object KeyDerivation extends ZIOSpecDefault, VaultTestContainerSupport {
 
   override def spec = suite("Key derivation benchmark")(
     deriveKeyBenchmark.provide(Apollo.prism14Layer),
-    queryKeyBenchmark.provide(vaultKvClientLayer, Apollo.prism14Layer)
+    queryKeyBenchmark.provide(vaultKvClientLayer(), Apollo.prism14Layer)
   ) @@ TestAspect.sequential @@ TestAspect.timed @@ TestAspect.tag("benchmark") @@ TestAspect.ignore
 
   private val deriveKeyBenchmark = suite("Key derivation benchmark")(

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/service/ManagedDIDServiceSpec.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/service/ManagedDIDServiceSpec.scala
@@ -77,7 +77,7 @@ object ManagedDIDServiceSpec
 
   private def vaultSecretStorageLayer =
     ZLayer.make[DIDSecretStorage & WalletSecretStorage](
-      VaultDIDSecretStorage.layer(true),
+      VaultDIDSecretStorage.layer(useSemanticPath = true),
       VaultWalletSecretStorage.layer,
       vaultKvClientLayer()
     )

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/service/ManagedDIDServiceSpec.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/service/ManagedDIDServiceSpec.scala
@@ -79,7 +79,7 @@ object ManagedDIDServiceSpec
     ZLayer.make[DIDSecretStorage & WalletSecretStorage](
       VaultDIDSecretStorage.layer(true),
       VaultWalletSecretStorage.layer,
-      vaultKvClientLayer
+      vaultKvClientLayer()
     )
 
   private def serviceLayer =

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/service/ManagedDIDServiceSpec.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/service/ManagedDIDServiceSpec.scala
@@ -77,7 +77,7 @@ object ManagedDIDServiceSpec
 
   private def vaultSecretStorageLayer =
     ZLayer.make[DIDSecretStorage & WalletSecretStorage](
-      VaultDIDSecretStorage.layer,
+      VaultDIDSecretStorage.layer(true),
       VaultWalletSecretStorage.layer,
       vaultKvClientLayer
     )

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/service/WalletManagementServiceSpec.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/service/WalletManagementServiceSpec.scala
@@ -51,7 +51,7 @@ object WalletManagementServiceSpec
         contextAwareTransactorLayer,
         pgContainerLayer,
         apolloLayer,
-        vaultKvClientLayer,
+        vaultKvClientLayer(),
       )
 
     suite("WalletManagementService")(suite1, suite2)

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/storage/DIDSecretStorageSpec.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/storage/DIDSecretStorageSpec.scala
@@ -49,10 +49,23 @@ object DIDSecretStorageSpec
         ZLayer.succeed(WalletAdministrationContext.Admin())
       )
 
-    val vaultTestSuite = commonSpec("VaultDIDSecretStorage")
+    val vaultTestSuite = commonSpec("VaultDIDSecretStorage - useSemanticPath = true")
       .provide(
         JdbcDIDNonSecretStorage.layer,
-        VaultDIDSecretStorage.layer,
+        VaultDIDSecretStorage.layer(useSemanticPath = true),
+        VaultWalletSecretStorage.layer,
+        systemTransactorLayer,
+        contextAwareTransactorLayer,
+        pgContainerLayer,
+        vaultKvClientLayer,
+        walletManagementServiceLayer,
+        ZLayer.succeed(WalletAdministrationContext.Admin())
+      )
+
+    val vaultTestSuite2 = commonSpec("VaultDIDSecretStorage - useSemanticPath = false")
+      .provide(
+        JdbcDIDNonSecretStorage.layer,
+        VaultDIDSecretStorage.layer(useSemanticPath = false),
         VaultWalletSecretStorage.layer,
         systemTransactorLayer,
         contextAwareTransactorLayer,
@@ -74,7 +87,12 @@ object DIDSecretStorageSpec
         ZLayer.succeed(WalletAdministrationContext.Admin())
       )
 
-    suite("DIDSecretStorage")(jdbcTestSuite, vaultTestSuite, inMemoryTestSuite) @@ TestAspect.sequential
+    suite("DIDSecretStorage")(
+      jdbcTestSuite,
+      vaultTestSuite,
+      vaultTestSuite2,
+      inMemoryTestSuite
+    ) @@ TestAspect.sequential
   }
 
   private def commonSpec(name: String) =

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/storage/DIDSecretStorageSpec.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/storage/DIDSecretStorageSpec.scala
@@ -145,7 +145,7 @@ object DIDSecretStorageSpec
         _ <- secretStorage.insertKey(peerDID.did, "agreement", peerDID.jwkForKeyAgreement)
         _ <- secretStorage.insertKey(peerDID.did, "authentication", peerDID.jwkForKeyAuthentication)
       } yield assertCompletes
-    } @@ TestAspect.tag("dev")
+    }
   ).globalWallet
 
   private val multiWalletSpec = suite("multi-wallet")(

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/storage/GenericSecretStorageSpec.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/storage/GenericSecretStorageSpec.scala
@@ -53,22 +53,22 @@ object GenericSecretStorageSpec
         ZLayer.succeed(WalletAdministrationContext.Admin())
       )
 
-    val vaultTestSuite = commonSpec("VaultGenericSecretStorage - useSemanticPath = true")
+    val vaultTestSuite = commonSpec("VaultGenericSecretStorage")
       .provide(
         VaultWalletSecretStorage.layer,
         VaultGenericSecretStorage.layer(useSemanticPath = true),
         pgContainerLayer,
-        vaultKvClientLayer,
+        vaultKvClientLayer(),
         walletManagementServiceLayer,
         ZLayer.succeed(WalletAdministrationContext.Admin())
       )
 
-    val vaultTestSuite2 = commonSpec("VaultGenericSecretStorage - useSemanticPath = false")
+    val vaultFsTestSuite = commonSpec("VaultGenericSecretStorage - file backend")
       .provide(
         VaultWalletSecretStorage.layer,
         VaultGenericSecretStorage.layer(useSemanticPath = false),
         pgContainerLayer,
-        vaultKvClientLayer,
+        vaultKvClientLayer(useFileBackend = true),
         walletManagementServiceLayer,
         ZLayer.succeed(WalletAdministrationContext.Admin())
       )
@@ -86,7 +86,7 @@ object GenericSecretStorageSpec
     suite("GenericSecretStorage")(
       jdbcTestSuite,
       vaultTestSuite,
-      vaultTestSuite2,
+      vaultFsTestSuite,
       inMemoryTestSuite
     ) @@ TestAspect.sequential
   }

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/storage/GenericSecretStorageSpec.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/storage/GenericSecretStorageSpec.scala
@@ -53,10 +53,20 @@ object GenericSecretStorageSpec
         ZLayer.succeed(WalletAdministrationContext.Admin())
       )
 
-    val vaultTestSuite = commonSpec("VaultGenericSecretStorage")
+    val vaultTestSuite = commonSpec("VaultGenericSecretStorage - useSemanticPath = true")
       .provide(
         VaultWalletSecretStorage.layer,
-        VaultGenericSecretStorage.layer,
+        VaultGenericSecretStorage.layer(useSemanticPath = true),
+        pgContainerLayer,
+        vaultKvClientLayer,
+        walletManagementServiceLayer,
+        ZLayer.succeed(WalletAdministrationContext.Admin())
+      )
+
+    val vaultTestSuite2 = commonSpec("VaultGenericSecretStorage - useSemanticPath = false")
+      .provide(
+        VaultWalletSecretStorage.layer,
+        VaultGenericSecretStorage.layer(useSemanticPath = false),
         pgContainerLayer,
         vaultKvClientLayer,
         walletManagementServiceLayer,
@@ -73,7 +83,12 @@ object GenericSecretStorageSpec
         ZLayer.succeed(WalletAdministrationContext.Admin())
       )
 
-    suite("GenericSecretStorage")(jdbcTestSuite, vaultTestSuite, inMemoryTestSuite) @@ TestAspect.sequential
+    suite("GenericSecretStorage")(
+      jdbcTestSuite,
+      vaultTestSuite,
+      vaultTestSuite2,
+      inMemoryTestSuite
+    ) @@ TestAspect.sequential
   }
 
   private def commonSpec(name: String) =

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/storage/WalletSecretStorageSpec.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/agent/walletapi/storage/WalletSecretStorageSpec.scala
@@ -34,7 +34,7 @@ object WalletSecretStorageSpec extends ZIOSpecDefault, PostgresTestContainerSupp
         JdbcWalletNonSecretStorage.layer,
         contextAwareTransactorLayer,
         pgContainerLayer,
-        vaultKvClientLayer
+        vaultKvClientLayer()
       )
 
     suite("WalletSecretStorage")(suite1, suite2)

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/test/container/VaultLayer.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/test/container/VaultLayer.scala
@@ -6,12 +6,12 @@ import io.iohk.atala.sharedtest.containers.VaultContainerCustom
 
 object VaultLayer {
 
-  def vaultLayer(vaultToken: String): TaskLayer[VaultContainerCustom] = {
+  def vaultLayer(vaultToken: String, useFileBackend: Boolean): TaskLayer[VaultContainerCustom] = {
     ZLayer
       .scoped {
         ZIO
           .acquireRelease(ZIO.attemptBlocking {
-            VaultTestContainer.vaultContainer(vaultToken = Some(vaultToken))
+            VaultTestContainer.vaultContainer(vaultToken = Some(vaultToken), useFileBackend = useFileBackend)
           })(container => ZIO.attemptBlocking(container.stop()).orDie)
           // Start the container outside the aquireRelease as this might fail
           // to ensure contianer.stop() is added to the finalizer

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/test/container/VaultTestContainerSupport.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/test/container/VaultTestContainerSupport.scala
@@ -1,9 +1,10 @@
 package io.iohk.atala.test.container
 
-import zio.*
 import io.iohk.atala.agent.walletapi.vault.VaultKVClient
 import io.iohk.atala.agent.walletapi.vault.VaultKVClientImpl
 import io.iohk.atala.sharedtest.containers.VaultContainerCustom
+import zio.*
+import zio.http.Client
 
 trait VaultTestContainerSupport {
 
@@ -12,12 +13,9 @@ trait VaultTestContainerSupport {
   protected val vaultContainerLayer: TaskLayer[VaultContainerCustom] = VaultLayer.vaultLayer(vaultToken = TEST_TOKEN)
 
   protected def vaultKvClientLayer: TaskLayer[VaultKVClient] =
-    vaultContainerLayer >>> ZLayer.fromFunction { (container: VaultContainerCustom) =>
+    vaultContainerLayer ++ Client.default >>> ZLayer.fromFunction { (container: VaultContainerCustom) =>
       val address = container.container.getHttpHostAddress()
-      ZLayer.fromZIO(
-        VaultKVClientImpl
-          .fromToken(address, TEST_TOKEN)
-      )
+      ZLayer.fromZIO(VaultKVClientImpl.fromToken(address, TEST_TOKEN))
     }.flatten
 
 }

--- a/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/test/container/VaultTestContainerSupport.scala
+++ b/prism-agent/service/wallet-api/src/test/scala/io/iohk/atala/test/container/VaultTestContainerSupport.scala
@@ -10,10 +10,11 @@ trait VaultTestContainerSupport {
 
   private val TEST_TOKEN = "root"
 
-  protected val vaultContainerLayer: TaskLayer[VaultContainerCustom] = VaultLayer.vaultLayer(vaultToken = TEST_TOKEN)
+  protected def vaultContainerLayer(useFileBackend: Boolean): TaskLayer[VaultContainerCustom] =
+    VaultLayer.vaultLayer(vaultToken = TEST_TOKEN, useFileBackend = useFileBackend)
 
-  protected def vaultKvClientLayer: TaskLayer[VaultKVClient] =
-    vaultContainerLayer ++ Client.default >>> ZLayer.fromFunction { (container: VaultContainerCustom) =>
+  protected def vaultKvClientLayer(useFileBackend: Boolean = false): TaskLayer[VaultKVClient] =
+    vaultContainerLayer(useFileBackend) ++ Client.default >>> ZLayer.fromFunction { (container: VaultContainerCustom) =>
       val address = container.container.getHttpHostAddress()
       ZLayer.fromZIO(VaultKVClientImpl.fromToken(address, TEST_TOKEN))
     }.flatten

--- a/shared-test/src/test/scala/io/iohk/atala/sharedtest/containers/VaultTestContainer.scala
+++ b/shared-test/src/test/scala/io/iohk/atala/sharedtest/containers/VaultTestContainer.scala
@@ -5,16 +5,18 @@ import org.testcontainers.utility.DockerImageName
 
 object VaultTestContainer {
   def vaultContainer(
-      imageName: String = "hashicorp/vault:1.15.0",
+      imageName: String = "hashicorp/vault:1.15.6",
       vaultToken: Option[String] = None,
-      verbose: Boolean = false
+      verbose: Boolean = false,
+      useFileBackend: Boolean = false
   ): VaultContainerCustom = {
     val isOnGithubRunner = sys.env.contains("GITHUB_NETWORK")
     val container =
       new VaultContainerCustom(
         dockerImageNameOverride = DockerImageName.parse(imageName),
         vaultToken = vaultToken,
-        isOnGithubRunner = isOnGithubRunner
+        isOnGithubRunner = isOnGithubRunner,
+        useFileBackend = useFileBackend
       )
     sys.env.get("GITHUB_NETWORK").map { network =>
       container.container.withNetworkMode(network)


### PR DESCRIPTION
### Description: 
Support config `VAULT_USE_SEMANTIC_PATH=false` to opt-out from using meaningful secret path for a fixed-length secret path. The path hierarchy is cut-off at certain depth and replaced by sha256 hash of path relative to the cut-off. The original path is stored in `semanticPath` key of the secret `custom_metadata` 

Fixes https://github.com/hyperledger-labs/open-enterprise-agent/issues/908

### Checklist: 
- [x] My PR follows the contribution guidelines of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
