### PR TITLE
tests: fix recovation new variable

### DIFF
--- a/prism-agent/service/server/src/main/resources/application.conf
+++ b/prism-agent/service/server/src/main/resources/application.conf
@@ -29,7 +29,8 @@ pollux {
     awaitConnectionThreads = ${?POLLUX_DB_AWAIT_CONNECTION_THREADS}
   }
   statusListRegistry {
-    publicEndpointUrl = "http://localhost:8085"
+    # defaults to the exposed AGENT_HTTP_PORT port
+    publicEndpointUrl = "http://localhost:"${?AGENT_HTTP_PORT}
     publicEndpointUrl = ${?POLLUX_STATUS_LIST_REGISTRY_PUBLIC_URL}
   }
   issueBgJobRecordsLimit = 25

--- a/tests/integration-tests/src/test/kotlin/config/services/Agent.kt
+++ b/tests/integration-tests/src/test/kotlin/config/services/Agent.kt
@@ -37,6 +37,7 @@ data class Agent(
             "KEYCLOAK_REALM" to (keycloak?.realm ?: ""),
             "KEYCLOAK_CLIENT_ID" to (keycloak?.clientId ?: ""),
             "KEYCLOAK_CLIENT_SECRET" to (keycloak?.clientSecret ?: ""),
+            "POLLUX_STATUS_LIST_REGISTRY_PUBLIC_URL" to "http://host.docker.internal:$httpPort"
         )
 
         // setup token authentication

--- a/tests/integration-tests/src/test/resources/containers/agent.yml
+++ b/tests/integration-tests/src/test/resources/containers/agent.yml
@@ -41,6 +41,7 @@ services:
       AGENT_HTTP_PORT:
       DIDCOMM_SERVICE_URL:
       REST_SERVICE_URL:
+      POLLUX_STATUS_LIST_REGISTRY_PUBLIC_URL:
       API_KEY_ENABLED:
       # Secret storage configuration
       SECRET_STORAGE_BACKEND:


### PR DESCRIPTION
### Description: 
- Fixes integration tests caused due new hard coded variable
- Bounds default value for `statusListRegistry.publicEndpointUrl` variable to `AGENT_HTTP_PORT`

### Checklist: 
- [] My PR follows the [contribution guidelines](https://github.com/hyperledger-labs/open-enterprise-agent/blob/main/CONTRIBUTING.md) of this project
- [] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
