### PR TITLE
fix(prism-agent): add missing 'PresentationVerificationFailed' status to REST API response enum

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/presentproof/controller/http/PresentationStatus.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/presentproof/controller/http/PresentationStatus.scala
@@ -102,6 +102,7 @@ object PresentationStatus {
               "PresentationSent",
               "PresentationReceived",
               "PresentationVerified",
+              "PresentationVerificationFailed",
               "PresentationAccepted",
               "PresentationRejected",
               "ProblemReportPending",


### PR DESCRIPTION
### Description: 
[ATL-6812](https://input-output.atlassian.net/browse/ATL-6812)

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-labs/open-enterprise-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
